### PR TITLE
ci: enable GitHub Actions workflow and build badges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+on:
+  - push
+  - pull_request
+jobs:
+  build:
+    name: Build on Node.js v${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # supported node versions
+        node: [14, 16]
+        os: ['ubuntu-latest']
+        include:
+          # additional test for current node version on windows
+          - node: 14
+            os: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm i -g npm
+      - run: |
+          echo "node: $(node --version)"
+          echo "npm: $(npm --version)"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build --workspaces
+      - run: npm run test --workspaces
+      - run: npm run synth:dev --workspaces

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: build
+
 on:
-  - push
-  - pull_request
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   build:
     name: Build on Node.js v${{ matrix.node }} on ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Baseline Environment on AWS
 
+[![release](https://img.shields.io/github/v/release/aws-samples/baseline-environment-on-aws)](https://github.com/aws-samples/baseline-environment-on-aws/releases)
+[![build](https://github.com/aws-samples/baseline-environment-on-aws/workflows/build/badge.svg)](https://github.com/aws-samples/baseline-environment-on-aws/actions?query=workflow%3A"build")
+
 [View this page in Japanese (日本語)](README_ja.md)
 
 Baseline Environment on AWS(BLEA) is a set of reference CDK template to establish secure baseline on standalone-account or ControlTower based multi-account AWS environment. This solution provides basic and extensible guardrail with AWS security services and end-to-end sample CDK code for typical system architecture. This template is also useful to learn more about AWS architecting best practices and how to customize CDK code as we incorporated comments in detail so that users can know why and how to customize.

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,5 +1,8 @@
 # Baseline Environment on AWS
 
+[![release](https://img.shields.io/github/v/release/aws-samples/baseline-environment-on-aws)](https://github.com/aws-samples/baseline-environment-on-aws/releases)
+[![build](https://github.com/aws-samples/baseline-environment-on-aws/workflows/build/badge.svg)](https://github.com/aws-samples/baseline-environment-on-aws/actions?query=workflow%3A"build")
+
 [In English](README.md)
 
 Baseline Environment on AWS(BLEA) は 単独の AWS アカウントまたは ControlTower で管理されたマルチアカウント環境で、セキュアなベースラインを確立するための リファレンス CDK テンプレート群です。このテンプレート群は AWS のセキュリティサービスを活用して基本的かつ拡張可能なガードレールを提供します。また典型的なシステムアーキテクチャを実現するエンドツーエンドの CDK サンプルコードを提供します。この CDK テンプレートは用途に合わせてユーザが拡張して使うことを前提としており、拡張の参考となるコードやコメントを多く含んでいます。これによって AWS のアーキテクチャベストプラクティスや CDK コードのカスタマイズを習得しやすくすることを目的としています。


### PR DESCRIPTION
Enable CI workflow using GitHub Actions and add some build badges to README.

This workflow implements basic build steps including lint, test, build, and cdk synth. We can run static checks before pull-request is merged. Workflow runs in below environment:

* Ubuntu + Node.js v14
* Ubuntu + Node.js v16
* Windows + Node.js v14

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
