### PR TITLE
ci: enable GitLab CI for implementation sample

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+default:
+    before_script:
+        - npm i -g npm
+        - echo node $(node --version)
+        - echo npm $(npm --version)
+        - npm ci --cache .npm --prefer-offline
+    cache:
+        key:
+            files:
+                - package-lock.json
+            prefix: ${CI_PROJECT_NAME}
+        paths:
+            - .npm/
+
+variables:
+    # Disable AWS profile in GitLab Runner to avoid unintended access during `cdk synth`.
+    # If you use your AWS account to deploy CDK apps, you should remove this, then set secret varibales in GitLab CI/CD settings from web.
+    AWS_PROFILE: ""
+    AWS_DEFAULT_REGION: ""
+    AWS_ACCESS_KEY_ID: ""
+    AWS_SECRET_ACCESS_KEY: ""
+
+.node-build: &node-build
+    - npm run lint
+    - npm run build --workspaces
+    - npm run test --workspaces
+    - npm run synth:dev --workspaces
+
+build-node14:
+    stage: build
+    image: node:14
+    script:
+        - *node-build
+
+build-node16:
+    stage: build
+    image: node:16
+    script:
+        - *node-build


### PR DESCRIPTION
Enable CI in GitLab CI. This doesn't work in GitHub, but this is valuable for users who have GitLab.

Note: Environment variables prefixed `AWS_` in GitLab Runner is expressly overriden with zero length string. This is set to prevent commands from unintentionally accessing the AWS environment using container's default credential.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
