### PR TITLE
docs: VS Code shortcut key for Mac

### DIFF
--- a/doc/HowTo.md
+++ b/doc/HowTo.md
@@ -45,7 +45,7 @@ This recommended extension is defined in `.vscode/extensions.json`. For more inf
 
 ### Configuring the VSCode Extension
 
-Press `Ctrl + Shift + p` (macOS: `Ctrl + Command + p`) to display the Command Palette and `Preferences:Open Select Settings (JSON)` Add the following settings:
+Press `Ctrl + Shift + p` (macOS: `Command + Shift + p`) to display the Command Palette and `Preferences:Open Select Settings (JSON)` Add the following settings:
 This will allow the code to be linted, formatting, etc. at the time of saving.
 
 ```json

--- a/doc/HowTo_ja.md
+++ b/doc/HowTo_ja.md
@@ -45,7 +45,7 @@ macOS の場合、 [Running Visual Studio Code on macOS](https://code.visualstud
 
 ### VSCode Extension の設定
 
-`Ctrl + Shift + p` (macOS: `Ctrl + Command + p`) を押してコマンドパレットを表示し、 `Preferences: Open Settings (JSON)` を選択します。以下の設定を追加します。
+`Ctrl + Shift + p` (macOS: `Command + Shift + p`) を押してコマンドパレットを表示し、 `Preferences: Open Settings (JSON)` を選択します。以下の設定を追加します。
 これによって保存時にコードの Linting、フォーマッティング等が行われるようになります。
 
 ```json


### PR DESCRIPTION
Fix VS Code shortcut key for Mac.
Key for opening Command Palette is `Command + Shift + p`.

--

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
