### PR TITLE
docs:  fix NIST quick start link in code comments

### DIFF
--- a/usecases/base-ct-guest/lib/blea-security-alarm-stack.ts
+++ b/usecases/base-ct-guest/lib/blea-security-alarm-stack.ts
@@ -75,7 +75,7 @@ export class BLEASecurityAlarmStack extends cdk.Stack {
     });
 
     // ------------ Detective guardrails from NIST standard template ----------------
-    // See: https://aws.amazon.com/quickstart/architecture/compliance-nist/?nc1=h_ls
+    // See: https://aws.amazon.com/blogs/publicsector/automating-compliance-architecting-for-fedramp-high-and-nist-workloads-in-aws-govcloud-us/
 
     // Security Groups Change Notification
     // See: https://aws.amazon.com/premiumsupport/knowledge-center/monitor-security-group-changes-ec2/?nc1=h_ls

--- a/usecases/base-standalone/lib/blea-security-alarm-stack.ts
+++ b/usecases/base-standalone/lib/blea-security-alarm-stack.ts
@@ -75,7 +75,7 @@ export class BLEASecurityAlarmStack extends cdk.Stack {
     });
 
     // ------------ Detective guardrails from NIST standard template ----------------
-    // See: https://aws.amazon.com/quickstart/architecture/compliance-nist/?nc1=h_ls
+    // See: https://aws.amazon.com/blogs/publicsector/automating-compliance-architecting-for-fedramp-high-and-nist-workloads-in-aws-govcloud-us/
 
     // Security Groups Change Notification
     // See: https://aws.amazon.com/premiumsupport/knowledge-center/monitor-security-group-changes-ec2/?nc1=h_ls


### PR DESCRIPTION
Updated the NIST quick start link as it was not a proper link.
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
