### PR TITLE
build: typescript from 4.4.4 to 4.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "prettier": "^2.4.1",
         "simple-git-hooks": "^2.6.1",
         "standard-version": "^9.3.2",
-        "typescript": "~4.4.4"
+        "typescript": "~4.5.5"
       },
       "engines": {
         "node": ">=14",
@@ -9393,9 +9393,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.4.4",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9732,18 +9733,6 @@
         "typescript": "~4.5.5"
       }
     },
-    "tools/cicd/node_modules/typescript": {
-      "version": "4.5.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "usecases/base-ct-audit": {
       "name": "blea-base-ct-audit",
       "version": "1.0.0",
@@ -9769,18 +9758,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      }
-    },
-    "usecases/base-ct-audit/node_modules/typescript": {
-      "version": "4.5.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "usecases/base-ct-guest": {
@@ -9810,18 +9787,6 @@
         "typescript": "~4.5.5"
       }
     },
-    "usecases/base-ct-guest/node_modules/typescript": {
-      "version": "4.5.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "usecases/base-standalone": {
       "name": "blea-base-standalone",
       "version": "1.0.0",
@@ -9848,18 +9813,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      }
-    },
-    "usecases/base-standalone/node_modules/typescript": {
-      "version": "4.5.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "usecases/guest-apiapp-sample": {
@@ -9892,18 +9845,6 @@
         "typescript": "~4.5.5"
       }
     },
-    "usecases/guest-apiapp-sample/node_modules/typescript": {
-      "version": "4.5.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "usecases/guest-webapp-sample": {
       "name": "blea-guest-ecsapp-sample",
       "version": "1.0.0",
@@ -9930,18 +9871,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      }
-    },
-    "usecases/guest-webapp-sample/node_modules/typescript": {
-      "version": "4.5.5",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     }
   },
@@ -12176,12 +12105,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.5.5",
-          "dev": true
-        }
       }
     },
     "blea-base-ct-guest": {
@@ -12202,12 +12125,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.5.5",
-          "dev": true
-        }
       }
     },
     "blea-base-standalone": {
@@ -12227,12 +12144,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.5.5",
-          "dev": true
-        }
       }
     },
     "blea-guest-apiapp-sample": {
@@ -12256,12 +12167,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.5.5",
-          "dev": true
-        }
       }
     },
     "blea-guest-ecsapp-sample": {
@@ -12283,12 +12188,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.5.5",
-          "dev": true
-        }
       }
     },
     "bleadeploy": {
@@ -12305,12 +12204,6 @@
         "ts-jest": "^27.1.3",
         "ts-node": "^10.4.0",
         "typescript": "~4.5.5"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.5.5",
-          "dev": true
-        }
       }
     },
     "brace-expansion": {
@@ -16187,7 +16080,9 @@
       }
     },
     "typescript": {
-      "version": "4.4.4",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "^2.4.1",
     "simple-git-hooks": "^2.6.1",
     "standard-version": "^9.3.2",
-    "typescript": "~4.4.4"
+    "typescript": "~4.5.5"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged"


### PR DESCRIPTION
The version specification of typescript in the root directory was different than in the subdirectories, so fix package.json in the root dir and reinstall it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
