### PR TITLE
docs: enable Inspector at Standalone and ControlTower

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,13 @@ This will set up the following features
 
 In addition to setting up a governance base, AWS provides several operational baseline services. Set up these services as needed.
 
-##### a. Perform AWS Systems Manager Quick Setup for EC2 Management
+##### a. Enabling Inspector and Detecting Vaulnerability
+
+Inspector automatically checks vulnerability. You can detect software vulnerability and unintended network exposure with continuous scanning by Inspector. You can view the detected vulnerabilities on your dashboard and prioritize them based on your calculated risk score, giving you greater visibility into your results. In addition, when vulnerabirities detected, it would be notified by the security hub.
+
+See: [https://docs.aws.amazon.com/inspector/latest/user/getting_started_tutorial.html]
+
+##### b. Perform AWS Systems Manager Quick Setup for EC2 Management
 
 If you use EC2, we recommend that you use SystemsManager to manage it. You can use AWS Systems Manager Quick Setup to automate the basic setup required to manage EC2.
 See: [https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-host-management.html]
@@ -272,7 +278,7 @@ Quick Setup provides the following features:
 - Installing and configuring Amazon CloudWatch Agent for the first time only
 - Monthly automatic updates of the CloudWatch agent
 
-##### b. Trusted Advisor Detection Results Report
+##### c. Trusted Advisor Detection Results Report
 
 TrustedAdvisor provides advice for following AWS best practices. It is possible to receive the contents of the report regularly by e-mail. Please refer to the following document for details.
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ In addition to setting up a governance base, AWS provides several operational ba
 
 ##### a. Enabling Inspector and Detecting Vaulnerability
 
-Inspector automatically checks vulnerability. You can detect software vulnerability and unintended network exposure with continuous scanning by Inspector. You can view the detected vulnerabilities on your dashboard and prioritize them based on your calculated risk score, giving you greater visibility into your results. In addition, when vulnerabirities detected, it would be notified by the security hub.
+Inspector automatically checks vulnerability. You can detect software vulnerability and unintended network exposure with continuous scanning by Inspector. You can view the detected vulnerabilities on your dashboard and prioritize them based on your calculated risk score, giving you greater visibility into your results. When enabled in conjunction with Security Hub, it would be automatically integrated and send the results to Security Hub.
 
 See: [https://docs.aws.amazon.com/inspector/latest/user/getting_started_tutorial.html]
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -256,7 +256,14 @@ npx cdk deploy --all -c environment=dev --profile prof_dev
 
 ガバナンスベースでセットアップする他に AWS はいくつかの運用上のベースラインサービスを提供しています。必要に応じてこれらのサービスのセットアップを行なってください。
 
-##### a. EC2 管理のため AWS Systems Manager Quick Setup を実施する
+##### a. Inspector を有効化
+
+Inspector は、脆弱性を管理します。EC2 とECR を継続的にスキャンして、ソフトウェアの脆弱性や意図しないネットワークのエクスポージャーをを検出します。検出された脆弱性は、算出されたリスクスコアに基づく優先順位により表示され、可視性高く結果を取得することができます。また、脆弱性を検知した際には、Security Hub 経由で通知することもできます。
+
+セットアップ手順：[https://docs.aws.amazon.com/inspector/latest/user/getting_started_tutorial.html]
+
+
+##### b. EC2 管理のため AWS Systems Manager Quick Setup を実施する
 
 EC2 を利用する場合は SystemsManager を利用して管理することをお勧めします。AWS Systems Manager Quick Setup を使うことで、EC2 の管理に必要な基本的なセットアップを自動化できます。
 セットアップ手順: [https://docs.aws.amazon.com/systems-manager/latest/userguide/quick-setup-host-management.html]
@@ -270,7 +277,7 @@ Quick Setup は以下の機能を提供します:
 - 初回のみの、Amazon CloudWatch agent のインストールと設定
 - CloudWatch agent の月次自動アップデート
 
-##### b. Trusted Advisor の検知結果レポート
+##### c. Trusted Advisor の検知結果レポート
 
 TrustedAdvisor は AWS のベストプラクティスをフォローするためのアドバイスを提供します。レポート内容を定期的にメールで受け取ることが可能です。詳細は下記ドキュメントを参照してください。
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -258,7 +258,7 @@ npx cdk deploy --all -c environment=dev --profile prof_dev
 
 ##### a. Inspector を有効化
 
-Inspector は、脆弱性を管理します。EC2 とECR を継続的にスキャンして、ソフトウェアの脆弱性や意図しないネットワークのエクスポージャーをを検出します。検出された脆弱性は、算出されたリスクスコアに基づく優先順位により表示され、可視性高く結果を取得することができます。また、脆弱性を検知した際には、Security Hub 経由で通知することもできます。
+Inspector は、脆弱性を管理します。EC2 とECR を継続的にスキャンして、ソフトウェアの脆弱性や意図しないネットワークのエクスポージャーをを検出します。検出された脆弱性は、算出されたリスクスコアに基づく優先順位により表示され、可視性高く結果を取得することができます。また、Scurity Hub と組み合わせて有効にすることで、自動で統合され Security Hub へ結果を送信します。
 
 セットアップ手順：[https://docs.aws.amazon.com/inspector/latest/user/getting_started_tutorial.html]
 

--- a/doc/DeployToControlTower.md
+++ b/doc/DeployToControlTower.md
@@ -63,11 +63,15 @@ See: [https://docs.aws.amazon.com/controltower/latest/userguide/setting-up.html]
 
 - [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html]
 
-#### 1-4. Setting Up the IAM Access Analyzer
+#### 1-4. Set up Inspector
+
+- [https://docs.aws.amazon.com/inspector/latest/user/designating-admin.html#delegated-admin-proc]
+
+#### 1-5. Setting Up the IAM Access Analyzer
 
 - [https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-settings.html#access-analyzer-delegated-administrator]
 
-#### 1-5. Set up Trusted Advisor
+#### 1-6. Set up Trusted Advisor
 
 - [https://docs.aws.amazon.com/awssupport/latest/user/organizational-view.html]
 
@@ -410,6 +414,7 @@ The following settings that were set up in the Standalone version are configured
 
 - API logging with CloudTrail
 - Recording configuration changes with AWS Config
+- Detecting vulnerability with Inspector
 - Detect abnormal behavior with GuardDuty
 - Detecting Deviations from Best Practices with SecurityHub (AWS Foundational Security Best Practice, CIS benchmark)
 

--- a/doc/DeployToControlTower.md
+++ b/doc/DeployToControlTower.md
@@ -65,7 +65,11 @@ See: [https://docs.aws.amazon.com/controltower/latest/userguide/setting-up.html]
 
 #### 1-4. Set up Inspector
 
+Designating a delegated administrator
 - [https://docs.aws.amazon.com/inspector/latest/user/designating-admin.html#delegated-admin-proc]
+
+Enabling scans for member accounts
+- [https://docs.aws.amazon.com/inspector/latest/user/adding-member-accounts.html]
 
 #### 1-5. Setting Up the IAM Access Analyzer
 

--- a/doc/DeployToControlTower_ja.md
+++ b/doc/DeployToControlTower_ja.md
@@ -65,7 +65,10 @@ See: [https://docs.aws.amazon.com/controltower/latest/userguide/setting-up.html]
 
 #### 1-4. Inspector のセットアップ
 
+委任された管理者権限の指定
 - [https://docs.aws.amazon.com/inspector/latest/user/designating-admin.html#delegated-admin-proc]
+メンバーアカウントでの有効化
+- [https://docs.aws.amazon.com/inspector/latest/user/adding-member-accounts.html]
 
 #### 1-5. IAM Access Analyzer のセットアップ
 

--- a/doc/DeployToControlTower_ja.md
+++ b/doc/DeployToControlTower_ja.md
@@ -47,7 +47,7 @@ ControlTower の配下にマルチアカウント版のガバナンスベース�
 
 ControlTower を利用することで、ガバナンスベースの一部の機能は自動的に設定されます。ControlTower が対応していないセキュリティサービスは Organizations に対して一括有効化を行うことで、以後新しいアカウントが作られると自動的に設定されるようになります。
 
-ここでは ControlTower をセットアップし、Organizations 全体に対して SecurityHub, GuardDuty そして IAM Access Analyzer を有効化する手順を示します。これらの委任アカウントとして Audit アカウントを指定します。
+ここでは ControlTower をセットアップし、Organizations 全体に対して SecurityHub, GuardDuty, Inspector そして IAM Access Analyzer を有効化する手順を示します。これらの委任アカウントとして Audit アカウントを指定します。
 
 #### 1-1. ControlTower のセットアップ
 
@@ -63,11 +63,15 @@ See: [https://docs.aws.amazon.com/controltower/latest/userguide/setting-up.html]
 
 - [https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html]
 
-#### 1-4. IAM Access Analyzer のセットアップ
+#### 1-4. Inspector のセットアップ
+
+- [https://docs.aws.amazon.com/inspector/latest/user/designating-admin.html#delegated-admin-proc]
+
+#### 1-5. IAM Access Analyzer のセットアップ
 
 - [https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-settings.html#access-analyzer-delegated-administrator]
 
-#### 1-5. Trusted Advisor のセットアップ
+#### 1-6. Trusted Advisor のセットアップ
 
 - [https://docs.aws.amazon.com/awssupport/latest/user/organizational-view.html]
 
@@ -408,6 +412,7 @@ Standalone 版でセットアップされていた以下の内容は ControlTowe
 
 - CloudTrail による API のロギング
 - AWS Config による構成変更の記録
+- Inspector による脆弱性の検出
 - GuardDuty による異常なふるまいの検知
 - SecurityHub によるベストプラクティスからの逸脱検知 (AWS Foundational Security Best Practice, CIS benchmark)
 

--- a/doc/Standalone2ControlTower.md
+++ b/doc/Standalone2ControlTower.md
@@ -29,6 +29,10 @@ On Management account, You need to have setup Baseline Environment on AWS with M
 
    Refer: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html
 
+5. Enable Inspector and automatically enabling new organization accounts
+
+   Refer: https://docs.aws.amazon.com/inspector/latest/user/adding-member-accounts.html
+
 # 1. Invite Target account to Management account Organizations
 
 ## 1.1. [Management Account] Invite account

--- a/doc/Standalone2ControlTower_ja.md
+++ b/doc/Standalone2ControlTower_ja.md
@@ -27,6 +27,10 @@ Baseline Environment on AWS の Standalone 版でセットアップしたアカ�
 
    参照: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_organizations.html
 
+5. Amazon Inspectorで新しい組織アカウントが自動有効化されている
+
+   参照: https://docs.aws.amazon.com/inspector/latest/user/adding-member-accounts.html
+
 # 1. ターゲットアカウントを マネジメントアカウントの Organizations へ招待する
 
 ターゲットアカウントを マネジメントアカウントの Organizations へ招待します。


### PR DESCRIPTION
add how to enable Inspector v2 manually. When Inspector enabled, the scanned results are sent to Security Hub automatically. 