### PR TITLE
ci: change to trigger CI on push to any branch as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: build
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
CI runs at the timing of the push to any branch of the forked repository to improve the efficiency of development.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
