### PR TITLE
ci: change node version of CI's windows environment from 14 to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         os: ['ubuntu-latest']
         include:
           # additional test for current node version on windows
-          - node: 14
+          - node: 16
             os: windows-latest
     steps:
       - run: |
@@ -28,8 +28,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
-      # TODO: Temporarily avoid 8.4 due to: https://github.com/npm/cli/issues/4341
-      - run: npm i -g npm@8.3
+      - run: npm i -g npm
       - run: |
           echo "node: $(node --version)"
           echo "npm: $(npm --version)"


### PR DESCRIPTION
Changed node version from 14 to 16 in Windows environment for CI. npm update command error occurs when CI is executed with node version 14 due to a bug here(https://github.com/npm/cli/issues/4341). In consideration of the fact that the active node version is 16(https://nodejs.org/en/about/releases/) and that CI runs in node14 in the ubuntu environment, only node16 is sufficient for CI in windows environment.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
