### PR TITLE
fix: vulnerabilities in minimist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7808,9 +7808,10 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -15134,7 +15135,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {


### PR DESCRIPTION
High severity in `minimist` is reported by `npm audit`
This issue is resolved by `npm audit fix` .
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0

--
## Appendix
### npm audit report

minimist  <=1.2.5
Severity: high
Prototype Pollution in minimist - https://github.com/advisories/GHSA-xvch-5gv4-984h
fix available via `npm audit fix`
node_modules/minimist

1 high severity vulnerability

To address all issues, run:
  npm audit fix