### PR TITLE
fix: AWSConfigRole is deprecated. The replacement policy is AWS_ConfigRole.

### DIFF
--- a/usecases/base-standalone/lib/blea-config-stack.ts
+++ b/usecases/base-standalone/lib/blea-config-stack.ts
@@ -10,7 +10,7 @@ export class BLEAConfigStack extends cdk.Stack {
 
     const role = new iam.Role(this, 'ConfigRole', {
       assumedBy: new iam.ServicePrincipal('config.amazonaws.com'),
-      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSConfigRole')],
+      managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWS_ConfigRole')],
     });
 
     new config.CfnConfigurationRecorder(this, 'ConfigRecorder', {

--- a/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
+++ b/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
@@ -1228,7 +1228,7 @@ Object {
                 Object {
                   "Ref": "AWS::Partition",
                 },
-                ":iam::aws:policy/service-role/AWSConfigRole",
+                ":iam::aws:policy/service-role/AWS_ConfigRole",
               ],
             ],
           },


### PR DESCRIPTION
※ReOpen PullRequest:#43
Follow the latest version of the IAM policy as the title suggests. The documents I referred to are as follows

https://docs.aws.amazon.com/config/latest/developerguide/security-iam-awsmanpol.html#security-iam-awsmanpol-AWS_ConfigRole
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
