### PR TITLE
Hotfix: bucket-enforce-ssl

### DIFF
--- a/usecases/base-standalone/lib/blea-config-stack.ts
+++ b/usecases/base-standalone/lib/blea-config-stack.ts
@@ -27,6 +27,7 @@ export class BLEAConfigStack extends cdk.Stack {
       versioned: true,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
       encryption: s3.BucketEncryption.S3_MANAGED,
+      enforceSSL: true,
     });
 
     // Attaches the AWSConfigBucketPermissionsCheck policy statement.

--- a/usecases/base-standalone/lib/blea-trail-stack.ts
+++ b/usecases/base-standalone/lib/blea-trail-stack.ts
@@ -19,6 +19,7 @@ export class BLEATrailStack extends cdk.Stack {
       versioned: true,
       encryption: s3.BucketEncryption.S3_MANAGED,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      enforceSSL: true,
       lifecycleRules: [
         {
           enabled: true,
@@ -42,6 +43,7 @@ export class BLEATrailStack extends cdk.Stack {
       serverAccessLogsBucket: archiveLogsBucket,
       serverAccessLogsPrefix: 'cloudtraillogs',
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      enforceSSL: true,
     });
     this.addBaseBucketPolicy(cloudTrailBucket);
 
@@ -118,21 +120,6 @@ export class BLEATrailStack extends cdk.Stack {
 
   // Add base BucketPolicy for CloudTrail
   addBaseBucketPolicy(bucket: s3.Bucket): void {
-    bucket.addToResourcePolicy(
-      new iam.PolicyStatement({
-        sid: 'Enforce HTTPS Connections',
-        effect: iam.Effect.DENY,
-        actions: ['s3:*'],
-        principals: [new iam.AnyPrincipal()],
-        resources: [bucket.arnForObjects('*')],
-        conditions: {
-          Bool: {
-            'aws:SecureTransport': false,
-          },
-        },
-      }),
-    );
-
     bucket.addToResourcePolicy(
       new iam.PolicyStatement({
         sid: 'Restrict Delete* Actions',

--- a/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
+++ b/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
@@ -168,28 +168,35 @@ Object {
               "Action": "s3:*",
               "Condition": Object {
                 "Bool": Object {
-                  "aws:SecureTransport": false,
+                  "aws:SecureTransport": "false",
                 },
               },
               "Effect": "Deny",
               "Principal": Object {
                 "AWS": "*",
               },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "ArchiveLogsBucketBC7EE643",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ArchiveLogsBucketBC7EE643",
+                    "Arn",
                   ],
-                ],
-              },
-              "Sid": "Enforce HTTPS Connections",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ArchiveLogsBucketBC7EE643",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
             Object {
               "Action": "s3:Delete*",
@@ -289,28 +296,35 @@ Object {
               "Action": "s3:*",
               "Condition": Object {
                 "Bool": Object {
-                  "aws:SecureTransport": false,
+                  "aws:SecureTransport": "false",
                 },
               },
               "Effect": "Deny",
               "Principal": Object {
                 "AWS": "*",
               },
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    Object {
-                      "Fn::GetAtt": Array [
-                        "CloudTrailBucket98B0BFE1",
-                        "Arn",
-                      ],
-                    },
-                    "/*",
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "CloudTrailBucket98B0BFE1",
+                    "Arn",
                   ],
-                ],
-              },
-              "Sid": "Enforce HTTPS Connections",
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "CloudTrailBucket98B0BFE1",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
             Object {
               "Action": "s3:Delete*",
@@ -1123,6 +1137,40 @@ Object {
         },
         "PolicyDocument": Object {
           "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "ConfigBucket2112C5EC",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "ConfigBucket2112C5EC",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
             Object {
               "Action": "s3:GetBucketAcl",
               "Effect": "Allow",

--- a/usecases/guest-webapp-sample/lib/blea-vpc-stack.ts
+++ b/usecases/guest-webapp-sample/lib/blea-vpc-stack.ts
@@ -63,6 +63,7 @@ export class BLEAVpcStack extends cdk.Stack {
       encryption: s3.BucketEncryption.KMS,
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       removalPolicy: cdk.RemovalPolicy.RETAIN,
+      enforceSSL: true,
     });
 
     myVpc.addFlowLog('FlowLogs', {

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-asgapp-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-asgapp-sample.test.ts.snap
@@ -419,6 +419,53 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "FlowLogBucketPolicyD22C263C": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "FlowLogBucket0863ACCA",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "FlowLogBucket0863ACCA",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "FlowLogBucket0863ACCA",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "Key961B73FD": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ec2app-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ec2app-sample.test.ts.snap
@@ -419,6 +419,53 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "FlowLogBucketPolicyD22C263C": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "FlowLogBucket0863ACCA",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "FlowLogBucket0863ACCA",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "FlowLogBucket0863ACCA",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "Key961B73FD": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-sample.test.ts.snap
@@ -475,6 +475,53 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "FlowLogBucketPolicyD22C263C": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "FlowLogBucket0863ACCA",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "FlowLogBucket0863ACCA",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "FlowLogBucket0863ACCA",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "Key961B73FD": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-ssl-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-ssl-sample.test.ts.snap
@@ -475,6 +475,53 @@ Object {
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
     },
+    "FlowLogBucketPolicyD22C263C": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "FlowLogBucket0863ACCA",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "FlowLogBucket0863ACCA",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "FlowLogBucket0863ACCA",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
+    },
     "Key961B73FD": Object {
       "DeletionPolicy": "Retain",
       "Properties": Object {


### PR DESCRIPTION
I noticed some buckets with and without "enforceSSL = true". I also found places where L1 was used without using L2Construct, but these seemed to be inevitable, so I fixed them as well.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
