### PR TITLE
docs: Add a guidance to deal with alerts about codebuild from security hub 

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ This completes the baseline and sample application deployment for a single accou
 > cd usecases/guest-webapp-sample
 > npx cdk deploy --all --app "npx ts-node bin/blea-guest-asgapp-sample.ts" -c environment=dev --profile prof_dev
 > ```
+>
+> NOTE:
+> When deploying a guest ECS application, one of the Security Hub standards, [CodeBuild.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5), may raise an alert. You can suppress the alert by referring to [Changing the status of notifications about CodeBuild's privileged mode](doc/HowTo.md#remediate-security-issues).
 
 #### 5-3. Develop your own applications
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -347,6 +347,9 @@ npx cdk deploy --all -c environment=dev --profile prof_dev
 > cd usecases/guest-webapp-sample
 > npx cdk deploy --all --app "npx ts-node bin/blea-guest-asgapp-sample.ts" -c environment=dev --profile prof_dev
 > ```
+>
+> NOTE:
+> ECS のゲストアプリケーションをデプロイした際に Security Hub のスタンダードの１つである[CodeBuild.5](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5)が警告を上げる可能性があります。[CodeBuild の特権モードに関する通知のステータスを変更する](doc/HowTo_ja.md#修復方法)を参照してこの警告を抑制することができます。
 
 #### 5-3. 独自のアプリケーションを開発する
 

--- a/doc/HowTo.md
+++ b/doc/HowTo.md
@@ -425,4 +425,15 @@ It is recommended that you use IDMSv2 only for metadata access on EC2 instances.
 - [EC2.8] EC2 instances should use IMDSv2
   - [https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8]
 
+### 3. CodeBuild の特権モードに関する通知のステータスを変更する
+
+CodeBuild should only enable privileged mode when building Docker images. If the following controls are out of compliance, check to see if the CodeBuild project needs to enable privileged mode, and if so, change the status of the workflow to SUPPRESSED.
+
+- [CodeBuild.5] CodeBuild project environments should not have privileged mode enabled
+  - [https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5]
+
+Refer to the following document how to change the status of a workflow.
+
+[https://docs.aws.amazon.com/securityhub/latest/userguide/finding-workflow-status.html]
+
 ---

--- a/doc/HowTo.md
+++ b/doc/HowTo.md
@@ -425,7 +425,7 @@ It is recommended that you use IDMSv2 only for metadata access on EC2 instances.
 - [EC2.8] EC2 instances should use IMDSv2
   - [https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8]
 
-### 3. CodeBuild の特権モードに関する通知のステータスを変更する
+### 3. Changing the status of notifications about CodeBuild's privileged mode
 
 CodeBuild should only enable privileged mode when building Docker images. If the following controls are out of compliance, check to see if the CodeBuild project needs to enable privileged mode, and if so, change the status of the workflow to SUPPRESSED.
 

--- a/doc/HowTo_ja.md
+++ b/doc/HowTo_ja.md
@@ -426,4 +426,15 @@ EC2 インスタンスのメタデータアクセスには IDMSv2 のみを使�
 - [EC2.8] EC2 instances should use IMDSv2
   - [https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8]
 
+### 3. CodeBuild の特権モードに関する通知のステータスを変更する
+
+CodeBuild では Docker イメージをビルドするときにのみ特権モードが有効化されるべきです。以下のコントロールがコンプライアンス違反となった場合には、その CodeBuild プロジェクトが特権モードを有効化する必要があるかを確認し、もし必要だと確認された場合にはワークフローのステータスを SUPPRESSED に変更します。
+
+- [CodeBuild.5] CodeBuild project environments should not have privileged mode enabled
+  - [https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-codebuild-5]
+
+ワークフローのステータスを変更する方法は以下のドキュメントを参照してください。
+
+[https://docs.aws.amazon.com/securityhub/latest/userguide/finding-workflow-status.html]
+
 ---


### PR DESCRIPTION
A standard for detecting container privileged mode has been added to the AWS Foundational Security Best Practices controls on the Security Hub. When deploying an ECS guest application, this standard is out of compliance, so a guide has been added on how to suppress that warning notification.



---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
