### PR TITLE
feat: Revise metrics filter for UnauthorizedAttemptsAlarm.

### DIFF
--- a/usecases/base-ct-guest/lib/blea-security-alarm-stack.ts
+++ b/usecases/base-ct-guest/lib/blea-security-alarm-stack.ts
@@ -181,7 +181,10 @@ export class BLEASecurityAlarmStack extends cdk.Stack {
     const mfUnauthorizedAttempts = new cwl.MetricFilter(this, 'UnauthorizedAttempts', {
       logGroup: cloudTrailLogGroup,
       filterPattern: {
-        logPatternString: '{($.errorCode=AccessDenied)||($.errorCode=UnauthorizedOperation)}',
+        // Exclude calls “Decrypt" event by config.amazonaws.com to ignore innocuous errors caused by AWS Config.
+        // That error occurs if you have KMS (CMK) encrypted environment variables in Lambda function.
+        logPatternString:
+          '{($.errorCode = "*UnauthorizedOperation" || $.errorCode = "AccessDenied*") && ($.eventName != "Decrypt" || $.userIdentity.invokedBy != "config.amazonaws.com" )}',
       },
       metricNamespace: 'CloudTrailMetrics',
       metricName: 'UnauthorizedAttemptsEventCount',

--- a/usecases/base-ct-guest/test/__snapshots__/blea-base-ct-guest.test.ts.snap
+++ b/usecases/base-ct-guest/test/__snapshots__/blea-base-ct-guest.test.ts.snap
@@ -1195,7 +1195,7 @@ Object {
     },
     "UnauthorizedAttemptsA72B9105": Object {
       "Properties": Object {
-        "FilterPattern": "{($.errorCode=AccessDenied)||($.errorCode=UnauthorizedOperation)}",
+        "FilterPattern": "{($.errorCode = \\"*UnauthorizedOperation\\" || $.errorCode = \\"AccessDenied*\\") && ($.eventName != \\"Decrypt\\" || $.userIdentity.invokedBy != \\"config.amazonaws.com\\" )}",
         "LogGroupName": "aws-controltower/CloudTrailLogs",
         "MetricTransformations": Array [
           Object {

--- a/usecases/base-standalone/lib/blea-security-alarm-stack.ts
+++ b/usecases/base-standalone/lib/blea-security-alarm-stack.ts
@@ -181,7 +181,10 @@ export class BLEASecurityAlarmStack extends cdk.Stack {
     const mfUnauthorizedAttempts = new cwl.MetricFilter(this, 'UnauthorizedAttempts', {
       logGroup: cloudTrailLogGroup,
       filterPattern: {
-        logPatternString: '{($.errorCode=AccessDenied)||($.errorCode=UnauthorizedOperation)}',
+        // Exclude calls “Decrypt" event by config.amazonaws.com to ignore innocuous errors caused by AWS Config.
+        // That error occurs if you have KMS (CMK) encrypted environment variables in Lambda function.
+        logPatternString:
+          '{($.errorCode = "*UnauthorizedOperation" || $.errorCode = "AccessDenied*") && ($.eventName != "Decrypt" || $.userIdentity.invokedBy != "config.amazonaws.com" )}',
       },
       metricNamespace: 'CloudTrailMetrics',
       metricName: 'UnauthorizedAttemptsEventCount',

--- a/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
+++ b/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
@@ -2351,7 +2351,7 @@ Object {
     },
     "UnauthorizedAttemptsA72B9105": Object {
       "Properties": Object {
-        "FilterPattern": "{($.errorCode=AccessDenied)||($.errorCode=UnauthorizedOperation)}",
+        "FilterPattern": "{($.errorCode = \\"*UnauthorizedOperation\\" || $.errorCode = \\"AccessDenied*\\") && ($.eventName != \\"Decrypt\\" || $.userIdentity.invokedBy != \\"config.amazonaws.com\\" )}",
         "LogGroupName": Object {
           "Fn::ImportValue": "BLEA-Trail:ExportsOutputRefCloudTrailLogGroup343A29D62364BB0C",
         },


### PR DESCRIPTION
Exclude calls “Decrypt" event by config.amazonaws.com to ignore innocuous errors caused by AWS Config.
That error occurs when Lambda function has a KMS (CMK) encrypted environment variable.

Sample error logged in CloudTrail:

```
{
    "eventVersion": "1.08",
    "userIdentity": {
        "type": "AssumedRole",
        "principalId": "XXXXXXXXXXXXXXXXXXXXX:LambdaDescribeHandlerSession",
-- snip ---
        "invokedBy": "config.amazonaws.com"
    },
    "eventTime": "2021-10-30T02:19:55Z",
    "eventSource": "kms.amazonaws.com",
    "eventName": "Decrypt",
    "awsRegion": "ap-northeast-1",
    "sourceIPAddress": "config.amazonaws.com",
    "userAgent": "config.amazonaws.com",
    "errorCode": "AccessDenied",
    "errorMessage": "User: arn:aws:sts::000000000000:assumed-role/aws-controltower-ConfigRecorderRole/LambdaDescribeHandlerSession is not authorized to perform: kms:Decrypt on resource: arn:aws:kms:ap-northeast-1:000000000000:key/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx because no resource-based policy allows the kms:Decrypt action",
-- snip --
}
```

