### PR TITLE
Fix image path in Migrate BLEA Standalone to BLEA Multi-Account(ja)

### DIFF
--- a/doc/Standalone2ControlTower_ja.md
+++ b/doc/Standalone2ControlTower_ja.md
@@ -51,7 +51,7 @@ Baseline Environment on AWS の Standalone 版でセットアップしたアカ�
 ## 2.1. AWS Config delivery channel を削除する
 
 1. ターゲットアカウントのマネジメントコンソールにログインし、CloudShell を起動します。
-   ![OpenConsole](/doc/images/OpenConsole.png)
+   ![OpenConsole](../doc/images/CloudShell-OpenConsole.png)
 2. AWS Config の Delivery channel 名 と Configuration recorder 名を取得します
 
 ```


### PR DESCRIPTION
## Why & What

Fix image path

- before

https://github.com/aws-samples/baseline-environment-on-aws/blob/323662f430dc281a9aead5cb26d3d4efb40ce7f9/doc/Standalone2ControlTower_ja.md#21-aws-config-delivery-channel-%E3%82%92%E5%89%8A%E9%99%A4%E3%81%99%E3%82%8B

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/2929102/173754303-3550db94-e7b8-4dca-8cf5-f03d68c7bc21.png">


- after 

https://github.com/koudaiii/baseline-environment-on-aws/blob/2e57e2dcf834cc913f6ac5c85ff4dd74d6903e1f/doc/Standalone2ControlTower_ja.md#21-aws-config-delivery-channel-%E3%82%92%E5%89%8A%E9%99%A4%E3%81%99%E3%82%8B

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/2929102/173754251-d59eafd5-c212-4d9a-8885-654ee89e6b84.png">


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
