### PR TITLE
docs: Fix image path(en and ja)

### DIFF
--- a/doc/HowTo.md
+++ b/doc/HowTo.md
@@ -217,7 +217,7 @@ see: [https://docs.aws.amazon.com/cloudshell/latest/userguide/limits.html]
 ### 1. Start CloudShell
 
 - Launch CloudShell by clicking the [>_] icon in the AWS Management Console (next to your account name in the top right corner of the screen)
-  ! [OpenConsole](doc/images/CloudShell-OpenConsole.png)
+  ![OpenConsole](../doc/images/CloudShell-OpenConsole.png)
 
 ### 2. Set up the CDK execution environment
 
@@ -233,7 +233,7 @@ sudo npm -g install npm
 
 1. Download the CDK code to be deployed and archive it with zip, etc.
 2. From the CloudShell screen, click [Action]-[Upload File] to upload the archived file
-   ![UploadFiles](doc/images/CloudShell-UploadFiles.png)
+   ![UploadFiles](../doc/images/CloudShell-UploadFiles.png)
 
 3. Extract uploaded files
 

--- a/doc/HowTo_ja.md
+++ b/doc/HowTo_ja.md
@@ -217,7 +217,7 @@ see: [https://docs.aws.amazon.com/cloudshell/latest/userguide/limits.html]
 ### 1. CloudShell を起動する
 
 - AWS マネジメントコンソールの [>_] アイコンをクリックして CloudShell を起動する (画面右上のアカウント名の隣)
-  ![OpenConsole](doc/images/CloudShell-OpenConsole.png)
+  ![OpenConsole](../doc/images/CloudShell-OpenConsole.png)
 
 ### 2. CDK の実行環境をセットアップする
 
@@ -233,7 +233,7 @@ sudo npm -g install npm
 
 1. デプロイ対象の CDK コードをダウンロードし、zip 等でアーカイブする。
 2. CloudShell の画面から [Action]-[Upload File] をクリックし、アーカイブしたファイルをアップロードする
-   ![UploadFiles](doc/images/CloudShell-UploadFiles.png)
+   ![UploadFiles](../doc/images/CloudShell-UploadFiles.png)
 
 3. アップロードしたファイルを展開する
 


### PR DESCRIPTION
## Why & What

Fix image path

- before

https://github.com/aws-samples/baseline-environment-on-aws/blob/1df2898abc9769d926617ae548f1d5af27979097/doc/HowTo_ja.md#1-cloudshell-%E3%82%92%E8%B5%B7%E5%8B%95%E3%81%99%E3%82%8B

https://github.com/aws-samples/baseline-environment-on-aws/blob/1df2898abc9769d926617ae548f1d5af27979097/doc/HowTo_ja.md#3-cdk-%E3%82%B3%E3%83%BC%E3%83%89%E3%82%92%E3%82%A2%E3%83%83%E3%83%97%E3%83%AD%E3%83%BC%E3%83%89%E3%81%99%E3%82%8B

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/2929102/180136216-6c95c102-00ee-4680-bb88-c21d67e08baf.png">

https://github.com/aws-samples/baseline-environment-on-aws/blob/1df2898abc9769d926617ae548f1d5af27979097/doc/HowTo.md#1-start-cloudshell

https://github.com/aws-samples/baseline-environment-on-aws/blob/1df2898abc9769d926617ae548f1d5af27979097/doc/HowTo.md#3-upload-cdk-code

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/2929102/180137070-18427be9-0928-4383-8707-0300b40b440b.png">


- after

<img width="1142" alt="image" src="https://user-images.githubusercontent.com/2929102/180135977-503d52d2-81af-4492-9819-35c6f80320ba.png">

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/2929102/180135912-9f1d9245-6cdb-4f88-a17e-9afd3b96b784.png">

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/2929102/180137227-09df4317-9027-408a-9e1a-47c38e44cf43.png">

<img width="1144" alt="image" src="https://user-images.githubusercontent.com/2929102/180137291-7527d6d4-b8a4-41af-b73a-f7d4c1235dd3.png">


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
