### PR TITLE
Revert "ci: github actions to be triggered by push to all branches (#40)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: build
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Prevent running GitHub Actions twice when dependabot pushes new branches in this repository.

This reverts commit ac938655fa05c7888f78f4417129643a8ec1fcf9.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
