### PR TITLE
fix: change guest web db identifier

### DIFF
--- a/usecases/guest-webapp-sample/lib/blea-db-aurora-pg-stack.ts
+++ b/usecases/guest-webapp-sample/lib/blea-db-aurora-pg-stack.ts
@@ -51,7 +51,7 @@ export class BLEADbAuroraPgStack extends cdk.Stack {
       //      cloudwatchLogsExports: ['error', 'general', 'slowquery', 'audit'],  // For Aurora MySQL
       cloudwatchLogsExports: ['postgresql'], // For Aurora PostgreSQL
       cloudwatchLogsRetention: logs.RetentionDays.THREE_MONTHS,
-      instanceIdentifierBase: 'instance',
+      instanceIdentifierBase: id,
     });
     cluster.connections.allowDefaultPortFrom(props.appServerSecurityGroup);
     this.dbClusterName = cluster.clusterIdentifier;

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-asgapp-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-asgapp-sample.test.ts.snap
@@ -2490,7 +2490,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance1",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg1",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },
@@ -2518,7 +2518,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance2",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg2",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ec2app-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ec2app-sample.test.ts.snap
@@ -2519,7 +2519,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance1",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg1",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },
@@ -2547,7 +2547,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance2",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg2",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-sample.test.ts.snap
@@ -3735,7 +3735,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance1",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg1",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },
@@ -3763,7 +3763,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance2",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg2",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-ssl-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-ssl-sample.test.ts.snap
@@ -4079,7 +4079,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance1",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg1",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },
@@ -4107,7 +4107,7 @@ Object {
           "Ref": "Aurora2CBAB212",
         },
         "DBInstanceClass": "db.t3.medium",
-        "DBInstanceIdentifier": "instance2",
+        "DBInstanceIdentifier": "BLEA-DBAuroraPg2",
         "DBSubnetGroupName": Object {
           "Ref": "AuroraSubnetsC4DF45C9",
         },


### PR DESCRIPTION
In guest-webapp-sample, Identifier of RDS Instance was constant string 'instance'. When multiple db stack was created, identifier was possible to conflict. So, identifier is changed to stack-name to set unique name.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
