### PR TITLE
feat: enable scan on push with pull through cache

### DIFF
--- a/usecases/guest-webapp-sample/lib/blea-ecsapp-stack.ts
+++ b/usecases/guest-webapp-sample/lib/blea-ecsapp-stack.ts
@@ -130,12 +130,21 @@ export class BLEAECSAppStack extends cdk.Stack {
 
     // Container
     const containerImage = 'docker/library/httpd';
+    const containerRepository = ecr.Repository.fromRepositoryName(
+      this,
+      'PullThrough',
+      `${ecrRepositoryPrefix}/${containerImage}`,
+    );
+
+    // The repository is automatically created by pull through cache, but you must specify it explicitly to enable ImageScanonPush.
+    new ecr.Repository(this, 'enableScanning', {
+      repositoryName: containerRepository.repositoryName,
+      imageScanOnPush: true,
+    });
+
     const ecsContainer = ecsTask.addContainer('EcsApp', {
       // -- Option 1: If you want to use your ECR repository with pull through cache, you can use like this.
-      image: ecs.ContainerImage.fromEcrRepository(
-        ecr.Repository.fromRepositoryName(this, 'PullThrough', `${ecrRepositoryPrefix}/${containerImage}`),
-        'latest',
-      ),
+      image: ecs.ContainerImage.fromEcrRepository(containerRepository, 'latest'),
 
       // -- Option 2: If you want to use your ECR repository, you can use like this.
       // --           You Need to create your repository and dockerimage, then pass it to this stack.

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-sample.test.ts.snap
@@ -3600,6 +3600,23 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
+    "enableScanning7E3D4D91": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "ImageScanningConfiguration": Object {
+          "ScanOnPush": true,
+        },
+        "RepositoryName": "ecr-blea-ecsapp/docker/library/httpd",
+        "Tags": Array [
+          Object {
+            "Key": "Environment",
+            "Value": "Development",
+          },
+        ],
+      },
+      "Type": "AWS::ECR::Repository",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
   "Rules": Object {
     "CheckBootstrapVersion": Object {

--- a/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-ssl-sample.test.ts.snap
+++ b/usecases/guest-webapp-sample/test/__snapshots__/blea-guest-ecsapp-ssl-sample.test.ts.snap
@@ -3944,6 +3944,23 @@ Object {
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
+    "enableScanning7E3D4D91": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "ImageScanningConfiguration": Object {
+          "ScanOnPush": true,
+        },
+        "RepositoryName": "ecr-blea-ecsapp/docker/library/httpd",
+        "Tags": Array [
+          Object {
+            "Key": "Environment",
+            "Value": "Development",
+          },
+        ],
+      },
+      "Type": "AWS::ECR::Repository",
+      "UpdateReplacePolicy": "Retain",
+    },
   },
   "Rules": Object {
     "CheckBootstrapVersion": Object {


### PR DESCRIPTION
Currently, imageScanonPush is not enabled for ECR repositories created by pull through cache.
This PR enables ImageScanonPush for ECR repository.