### PR TITLE
ci: increase dependabot PR limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
+    open-pull-requests-limit: 30
     schedule:
       interval: 'weekly'
       day: 'monday'
@@ -17,6 +18,7 @@ updates:
         versions: '>=28'
   - package-ecosystem: 'docker' # See documentation for possible values
     directory: '/' # Location of package manifests
+    open-pull-requests-limit: 30
     schedule:
       interval: 'weekly'
       day: 'monday'


### PR DESCRIPTION
Because of throttling, increase limits of PR.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
