### PR TITLE
ci: add bot to update shapshot test in PR

### DIFF
--- a/.github/workflows/pr-bot-snapshot-update.yml
+++ b/.github/workflows/pr-bot-snapshot-update.yml
@@ -1,0 +1,46 @@
+name: PR bot for snapshot updating
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  build:
+    if: ${{github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && github.event.comment.body == '/snapshot update'}}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Checkout pull request branch
+        run: hub pr checkout ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Respond to comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment ${{ github.event.issue.pull_request.html_url }} --body "Hi @${{github.event.comment.user.login}}! Starting snapshot update ..."
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: npm
+      - name: Update npm and check versions
+        run: |
+          npm i -g npm
+          echo "node: $(node --version)"
+          echo "npm: $(npm --version)"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run automated tests
+        run: npm run test --workspaces -- -u
+      - name: Commit and push updates
+        run: |
+          echo $(git branch --show-current | rev | cut -d'/' -f1 | rev)
+          git config user.name "Snapshot bot"
+          git config user.email "action@github.com"
+          git status
+          git add -A
+          git commit --no-verify -m "build(deps): update snapshot for $(git branch --show-current | rev | cut -d'/' -f1 | rev)"
+          git push


### PR DESCRIPTION
To make updating snapshot easy, add a PR bot. The bot is triggerd by commenting `/snapshot update` in PR, and it pulls the branch and do `npm test --workspaces -- -u`, then commit and push it.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
