### PR TITLE
feat(chatbot): Migrate the AWS ChatBot to L2 Constructs.

### DIFF
--- a/usecases/base-ct-guest/lib/blea-chatbot-stack.ts
+++ b/usecases/base-ct-guest/lib/blea-chatbot-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { aws_chatbot as cb } from 'aws-cdk-lib';
 import { aws_iam as iam } from 'aws-cdk-lib';
+import { aws_sns as sns } from 'aws-cdk-lib';
 
 export interface BLEAChatbotStackProps extends cdk.StackProps {
   topicArn: string;
@@ -15,22 +16,15 @@ export class BLEAChatbotStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: BLEAChatbotStackProps) {
     super(scope, id, props);
 
-    // AWS Chatbot configuration for sending message
-    const chatbotRole = new iam.Role(this, 'ChatbotRole', {
-      assumedBy: new iam.ServicePrincipal('chatbot.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('ReadOnlyAccess'),
-        iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchReadOnlyAccess'),
-      ],
+    // !!! Create SlackChannel and add aws chatbot app to the room
+    const slackChatbotChannel = new cb.SlackChannelConfiguration(this, 'ChatbotChannel', {
+      slackChannelConfigurationName: `${id}-${props.workspaceId}`,
+      slackChannelId: props.channelId,
+      slackWorkspaceId: props.workspaceId,
     });
 
-    // !!! Create SlackChannel and add aws chatbot app to the room
-    new cb.CfnSlackChannelConfiguration(this, 'ChatbotChannel', {
-      configurationName: `${id}-${props.workspaceId}`,
-      slackChannelId: props.channelId,
-      iamRoleArn: chatbotRole.roleArn,
-      slackWorkspaceId: props.workspaceId,
-      snsTopicArns: [props.topicArn],
-    });
+    // AWS Chatbot configuration for sending message
+    slackChatbotChannel.addNotificationTopic(sns.Topic.fromTopicArn(this, 'ChatbotTopic', props.topicArn));
+    slackChatbotChannel.role?.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('ReadOnlyAccess'));
   }
 }

--- a/usecases/base-ct-guest/test/__snapshots__/blea-base-ct-guest.test.ts.snap
+++ b/usecases/base-ct-guest/test/__snapshots__/blea-base-ct-guest.test.ts.snap
@@ -1126,12 +1126,12 @@ Object {
     },
   },
   "Resources": Object {
-    "ChatbotChannel": Object {
+    "ChatbotChannel0C037C2E": Object {
       "Properties": Object {
         "ConfigurationName": "BLEA-ChatbotSecurity-T8XXXXXXX",
         "IamRoleArn": Object {
           "Fn::GetAtt": Array [
-            "ChatbotRole8A87AA1F",
+            "ChatbotChannelConfigurationRoleFD7AD2E3",
             "Arn",
           ],
         },
@@ -1145,7 +1145,7 @@ Object {
       },
       "Type": "AWS::Chatbot::SlackChannelConfiguration",
     },
-    "ChatbotRole8A87AA1F": Object {
+    "ChatbotChannelConfigurationRoleFD7AD2E3": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1169,18 +1169,6 @@ Object {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/ReadOnlyAccess",
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchReadOnlyAccess",
               ],
             ],
           },

--- a/usecases/base-standalone/lib/blea-chatbot-stack.ts
+++ b/usecases/base-standalone/lib/blea-chatbot-stack.ts
@@ -2,6 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { aws_chatbot as cb } from 'aws-cdk-lib';
 import { aws_iam as iam } from 'aws-cdk-lib';
+import { aws_sns as sns } from 'aws-cdk-lib';
 
 export interface BLEAChatbotStackProps extends cdk.StackProps {
   topicArn: string;
@@ -15,22 +16,15 @@ export class BLEAChatbotStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: BLEAChatbotStackProps) {
     super(scope, id, props);
 
-    // AWS Chatbot configuration for sending message
-    const chatbotRole = new iam.Role(this, 'ChatbotRole', {
-      assumedBy: new iam.ServicePrincipal('chatbot.amazonaws.com'),
-      managedPolicies: [
-        iam.ManagedPolicy.fromAwsManagedPolicyName('ReadOnlyAccess'),
-        iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchReadOnlyAccess'),
-      ],
+    // !!! Create SlackChannel and add aws chatbot app to the room
+    const slackChatbotChannel = new cb.SlackChannelConfiguration(this, 'ChatbotChannel', {
+      slackChannelConfigurationName: `${id}-${props.workspaceId}`,
+      slackChannelId: props.channelId,
+      slackWorkspaceId: props.workspaceId,
     });
 
-    // !!! Create SlackChannel and add aws chatbot app to the room
-    new cb.CfnSlackChannelConfiguration(this, 'ChatbotChannel', {
-      configurationName: `${id}-${props.workspaceId}`,
-      slackChannelId: props.channelId,
-      iamRoleArn: chatbotRole.roleArn,
-      slackWorkspaceId: props.workspaceId,
-      snsTopicArns: [props.topicArn],
-    });
+    // AWS Chatbot configuration for sending message
+    slackChatbotChannel.addNotificationTopic(sns.Topic.fromTopicArn(this, 'ChatbotTopic', props.topicArn));
+    slackChatbotChannel.role?.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('ReadOnlyAccess'));
   }
 }

--- a/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
+++ b/usecases/base-standalone/test/__snapshots__/blea-base-sa.test.ts.snap
@@ -1699,12 +1699,12 @@ Object {
     },
   },
   "Resources": Object {
-    "ChatbotChannel": Object {
+    "ChatbotChannel0C037C2E": Object {
       "Properties": Object {
         "ConfigurationName": "BLEA-ChatbotSecurity-T8XXXXXXX",
         "IamRoleArn": Object {
           "Fn::GetAtt": Array [
-            "ChatbotRole8A87AA1F",
+            "ChatbotChannelConfigurationRoleFD7AD2E3",
             "Arn",
           ],
         },
@@ -1718,7 +1718,7 @@ Object {
       },
       "Type": "AWS::Chatbot::SlackChannelConfiguration",
     },
-    "ChatbotRole8A87AA1F": Object {
+    "ChatbotChannelConfigurationRoleFD7AD2E3": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {
           "Statement": Array [
@@ -1742,18 +1742,6 @@ Object {
                   "Ref": "AWS::Partition",
                 },
                 ":iam::aws:policy/ReadOnlyAccess",
-              ],
-            ],
-          },
-          Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                "arn:",
-                Object {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/CloudWatchReadOnlyAccess",
               ],
             ],
           },


### PR DESCRIPTION
The AWS chatbot has been able to use L2 Constructs for some time, but in BLEA, L1 Constructs are adopted. This PR proposal is a corrective measure to address this. 

By the way, since it seems that 'CloudWatchReadOnlyAccess' is unnecessary if there is 'ReadOnlyAccess', this has been removed. The snapshot has also been updated.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
