### PR TITLE
fix: add ObjectOwnership property

### DIFF
--- a/usecases/blea-guest-ecs-app-sample/lib/construct/frontend.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/construct/frontend.ts
@@ -192,6 +192,7 @@ export class Frontend extends Construct {
         blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
         removalPolicy: cdk.RemovalPolicy.RETAIN,
         enforceSSL: true,
+        objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
       }),
       logIncludesCookies: true,
       logFilePrefix: 'CloudFrontAccessLogs/',

--- a/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
+++ b/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
@@ -3424,6 +3424,13 @@ Object {
             },
           ],
         },
+        "OwnershipControls": Object {
+          "Rules": Array [
+            Object {
+              "ObjectOwnership": "ObjectWriter",
+            },
+          ],
+        },
         "PublicAccessBlockConfiguration": Object {
           "BlockPublicAcls": true,
           "BlockPublicPolicy": true,


### PR DESCRIPTION
Fix #363.

Added `ObjectOwnership` property to the bucket that stores CloudFront access logs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
