### PR TITLE
fix: metrics name

### DIFF
--- a/usecases/blea-guest-ecs-app-sample/lib/construct/dashboard.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/construct/dashboard.ts
@@ -201,7 +201,7 @@ export class Dashboard extends Construct {
     });
     const albTgTLSNegotiationErrors = new cw.Metric({
       namespace: 'AWS/ApplicationELB',
-      metricName: 'TargetConnectionErrorCount',
+      metricName: 'TargetTLSNegotiationErrorCount',
       dimensionsMap: {
         LoadBalancer: props.albFullName,
       },
@@ -474,7 +474,7 @@ export class Dashboard extends Construct {
     });
     const dbWriterDMLLatency = new cw.Metric({
       namespace: 'AWS/RDS',
-      metricName: 'DeleteLatency',
+      metricName: 'DMLLatency',
       dimensionsMap: {
         DBClusterIdentifier: props.dbClusterName,
         Role: 'WRITER',

--- a/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
+++ b/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
@@ -4325,6 +4325,10 @@ Object {
               Object {
                 "Fn::ImportValue": "Dev-BLEAEcsApp:ExportsOutputRefDatastoreAuroraCluster2FE23DD58102FDEF",
               },
+              "\\",\\"Role\\",\\"WRITER\\",{\\"label\\":\\"\${PROP('MetricName')} /\${PROP('Period')}sec\\",\\"period\\":60}],[\\"AWS/RDS\\",\\"DMLLatency\\",\\"DBClusterIdentifier\\",\\"",
+              Object {
+                "Fn::ImportValue": "Dev-BLEAEcsApp:ExportsOutputRefDatastoreAuroraCluster2FE23DD58102FDEF",
+              },
               "\\",\\"Role\\",\\"WRITER\\",{\\"label\\":\\"\${PROP('MetricName')} /\${PROP('Period')}sec\\",\\"period\\":60}],[\\"AWS/RDS\\",\\"ReadLatency\\",\\"DBClusterIdentifier\\",\\"",
               Object {
                 "Fn::ImportValue": "Dev-BLEAEcsApp:ExportsOutputRefDatastoreAuroraCluster2FE23DD58102FDEF",
@@ -4404,6 +4408,10 @@ Object {
                 "Fn::ImportValue": "Dev-BLEAEcsApp:ExportsOutputFnGetAttEcsAppAlb74CC21B3LoadBalancerFullName06D09417",
               },
               "\\",{\\"label\\":\\"\${PROP('MetricName')} /\${PROP('Period')}sec\\",\\"period\\":60,\\"stat\\":\\"Sum\\"}],[\\"AWS/ApplicationELB\\",\\"TargetConnectionErrorCount\\",\\"LoadBalancer\\",\\"",
+              Object {
+                "Fn::ImportValue": "Dev-BLEAEcsApp:ExportsOutputFnGetAttEcsAppAlb74CC21B3LoadBalancerFullName06D09417",
+              },
+              "\\",{\\"label\\":\\"\${PROP('MetricName')} /\${PROP('Period')}sec\\",\\"period\\":60,\\"stat\\":\\"Sum\\"}],[\\"AWS/ApplicationELB\\",\\"TargetTLSNegotiationErrorCount\\",\\"LoadBalancer\\",\\"",
               Object {
                 "Fn::ImportValue": "Dev-BLEAEcsApp:ExportsOutputFnGetAttEcsAppAlb74CC21B3LoadBalancerFullName06D09417",
               },


### PR DESCRIPTION
Some CloudWatch Metrics seem to have incorrect names.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
