### PR TITLE
chore(ecs-app): Use http:2.4.57 container image instead of latest

### DIFF
--- a/usecases/blea-guest-ecs-app-sample/lib/construct/ecsapp.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/construct/ecsapp.ts
@@ -230,7 +230,7 @@ export class EcsApp extends Construct {
 
     const ecsContainer = taskDefinition.addContainer('App', {
       // -- Option 1: If you want to use your ECR repository with pull through cache, you can use like this.
-      image: ecs.ContainerImage.fromEcrRepository(containerRepository, 'latest'),
+      image: ecs.ContainerImage.fromEcrRepository(containerRepository, '2.4.57'),
 
       // -- Option 2: If you want to use your ECR repository, you can use like this.
       // --           You Need to create your repository and dockerimage, then pass it to this stack.

--- a/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
+++ b/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
@@ -1583,7 +1583,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
                   {
                     "Ref": "AWS::URLSuffix",
                   },
-                  "/devblecsapp-af22469e/docker/library/httpd:latest",
+                  "/devblecsapp-af22469e/docker/library/httpd:2.4.57",
                 ],
               ],
             },


### PR DESCRIPTION
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
