### PR TITLE
fix: Security Hub Service Linked Role (SLR) conflicts in multi-region BLEA deployment

### DIFF
--- a/usecases/blea-gov-base-standalone/lib/construct/detection.ts
+++ b/usecases/blea-gov-base-standalone/lib/construct/detection.ts
@@ -28,9 +28,11 @@ export class Detection extends Construct {
     });
 
     // === AWS Security Hub ===
-    new iam.CfnServiceLinkedRole(this, 'SecurityHubRole', {
-      awsServiceName: 'securityhub.amazonaws.com',
-    });
+    iam.Role.fromRoleArn(
+      this,
+      'existSecurityHubRole',
+      `arn:aws:iam::${cdk.Aws.ACCOUNT_ID}:role/aws-service-role/securityhub.amazonaws.com/AWSServiceRoleForSecurityHub`,
+    );
 
     new hub.CfnHub(this, 'SecurityHub');
 

--- a/usecases/blea-gov-base-standalone/test/__snapshots__/blea-gov-base-standalone.test.ts.snap
+++ b/usecases/blea-gov-base-standalone/test/__snapshots__/blea-gov-base-standalone.test.ts.snap
@@ -1365,29 +1365,6 @@ exports[`Snapshot test for BLEAGovBaseStandalone Stack 1`] = `
       },
       "Type": "AWS::Events::Rule",
     },
-    "DetectionSecurityHubRoleDBC68A4D": {
-      "DependsOn": [
-        "LoggingCloudTrailLogsRoleDefaultPolicy7A5B650C",
-        "LoggingCloudTrailLogsRoleE1DD6030",
-        "LoggingCloudTrail44E92DB9",
-        "LoggingCloudTrailAccessLogBucketPolicyE58866E2",
-        "LoggingCloudTrailAccessLogBucketA7B773C8",
-        "LoggingCloudTrailBucketPolicy4004472F",
-        "LoggingCloudTrailBucket7560781D",
-        "LoggingCloudTrailKeyAlias65A5FEEA",
-        "LoggingCloudTrailKey43327553",
-        "LoggingCloudTrailLogGroupEFC12822",
-        "LoggingConfigBucketPolicy66A7F5E7",
-        "LoggingConfigBucket139B5174",
-        "LoggingConfigDeliveryChannel44B4762B",
-        "LoggingConfigRecorderFC55B19F",
-        "LoggingConfigRole0E4FDF1F",
-      ],
-      "Properties": {
-        "AWSServiceName": "securityhub.amazonaws.com",
-      },
-      "Type": "AWS::IAM::ServiceLinkedRole",
-    },
     "DetectionSgChangedEventRule80666B19": {
       "DependsOn": [
         "LoggingCloudTrailLogsRoleDefaultPolicy7A5B650C",


### PR DESCRIPTION
# What I want to do

I want to use BLEA for both Tokyo and Sydney as development and staging environments using one account.

# What I expected

Successfully deploy to both regions.

# What actually happened.

Deployment to the second region failed with the following error.

```
Stage-BLEAGovBaseStandalone | 49/70 | 22:53:10 | CREATE_FAILED    | AWS::IAM::ServiceLinkedRole       | Detection/SecurityHubRole (DetectionSecurityHubRoleDBC68A4D) Resource handler returned message: "Service role name AWSSe            
rviceRoleForSecurityHub has been taken in this account, please try a different suffix. (Service: Iam, Status Code: 400, Request ID: f96f8939-20eb-44c4-bd61-de301d4c894d)" (RequestToken: c0ceedae-1d5a-efbe-7743-4371217f0dd5, HandlerErr            
orCode: AlreadyExists)  
```

# Cause of trouble

Since the service-linked role for Security Hub is already created during the initial deployment to the first region, it cannot be created during the deployment to the second region, resulting in the above-mentioned error.
 
```
export class Detection extends Construct {
(snip)
  // === AWS Security Hub ===
  new iam.CfnServiceLinkedRole(this, 'SecurityHubRole', {
   awsServiceName: 'securityhub.amazonaws.com',
  });
  new hub.CfnHub(this, 'SecurityHub');
(snip)
```

# About this pull request

This PR solves this problem. Instead of creating Security Hub SLR, this implementation is to refer it. So it does not happen Security Hub SLR conflict.

# Note

Security Hub SLR remains after deleting BLEA deployment.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
