### PR TITLE
fix(blea-guest-serverless-api-sample): lambda runtime version and snapshot update

### DIFF
--- a/usecases/blea-guest-serverless-api-sample/lib/construct/lambda-nodejs.ts
+++ b/usecases/blea-guest-serverless-api-sample/lib/construct/lambda-nodejs.ts
@@ -60,7 +60,7 @@ export class LambdaNodejs extends Construct {
 
     // GetItem Function
     const getItemFunction = new node_lambda.NodejsFunction(this, 'GetItemFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_LATEST,
       entry: 'lambda/nodejs/getItem.js',
       handler: 'getItem',
       memorySize: 256,
@@ -147,7 +147,7 @@ export class LambdaNodejs extends Construct {
 
     // ListItem Function
     const listItemsFunction = new node_lambda.NodejsFunction(this, 'ListItemsFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_LATEST,
       entry: 'lambda/nodejs/listItems.js',
       handler: 'listItems',
       timeout: cdk.Duration.seconds(25),
@@ -233,7 +233,7 @@ export class LambdaNodejs extends Construct {
 
     // PutItem Function
     const putItemFunction = new node_lambda.NodejsFunction(this, 'PutItemFunction', {
-      runtime: lambda.Runtime.NODEJS_14_X,
+      runtime: lambda.Runtime.NODEJS_LATEST,
       entry: 'lambda/nodejs/putItem.js',
       handler: 'putItem',
       timeout: cdk.Duration.seconds(25),

--- a/usecases/blea-guest-serverless-api-sample/lib/construct/lambda-python.ts
+++ b/usecases/blea-guest-serverless-api-sample/lib/construct/lambda-python.ts
@@ -65,12 +65,12 @@ export class LambdaPython extends Construct {
     const lambdaPowertools = lambda.LayerVersion.fromLayerVersionArn(
       this,
       'lambda-powertools',
-      `arn:aws:lambda:${cdk.Stack.of(this).region}:017000801446:layer:AWSLambdaPowertoolsPython:3`,
+      `arn:aws:lambda:${cdk.Stack.of(this).region}:017000801446:layer:AWSLambdaPowertoolsPythonV2:60`,
     );
 
     // GetItem Function
     const getItemFunction = new lambda.Function(this, 'GetItemFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset('lambda/python/getItem'),
       handler: 'getItem.lambda_handler',
       memorySize: 256,
@@ -158,7 +158,7 @@ export class LambdaPython extends Construct {
 
     // ListItem Function
     const listItemsFunction = new lambda.Function(this, 'ListItemsFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset('lambda/python/listItems'),
       handler: 'listItems.lambda_handler',
       timeout: cdk.Duration.seconds(25),
@@ -246,7 +246,7 @@ export class LambdaPython extends Construct {
 
     // PutItem Function
     const putItemFunction = new lambda.Function(this, 'PutItemFunction', {
-      runtime: lambda.Runtime.PYTHON_3_7,
+      runtime: lambda.Runtime.PYTHON_3_12,
       code: lambda.Code.fromAsset('lambda/python/putItem'),
       handler: 'putItem.lambda_handler',
       timeout: cdk.Duration.seconds(25),

--- a/usecases/blea-guest-serverless-api-sample/test/__snapshots__/blea-guest-apiapp-nodejs-sample.test.ts.snap
+++ b/usecases/blea-guest-serverless-api-sample/test/__snapshots__/blea-guest-apiapp-nodejs-sample.test.ts.snap
@@ -77,7 +77,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "1c605bf16478b51860cca556fdfb1e37f5024de19e01232fcb3455ae08708b60.zip",
+          "S3Key": "2a9875eb37263cf2556e6f088d5f20034e2fd3b8c2176c6332c8a8fcfc3cfd2a.zip",
         },
         "Environment": {
           "Variables": {
@@ -104,7 +104,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 25,
         "TracingConfig": {
           "Mode": "Active",
@@ -257,7 +257,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "21c0d46dba304aebe7819d962d091864231949de414d5f232f3d71f536ab3e82.zip",
+          "S3Key": "68a11c84212c3eff28df00c3bf5918304911369738721962565d7b7e22635f1d.zip",
         },
         "Environment": {
           "Variables": {
@@ -284,7 +284,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 25,
         "TracingConfig": {
           "Mode": "Active",
@@ -437,7 +437,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "5779f9584321924cd8199013da6cb79193587b02e3ea4e372217c849d5ac2b0d.zip",
+          "S3Key": "8f98da062af0ac11372a014910ace092e8d07c085ee89aac238241a5b6b7c6f5.zip",
         },
         "Environment": {
           "Variables": {
@@ -464,7 +464,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs18.x",
         "Timeout": 25,
         "TracingConfig": {
           "Mode": "Active",
@@ -955,7 +955,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           ],
         },
         "Layers": [
-          "arn:aws:lambda:ap-northeast-1:017000801446:layer:AWSLambdaPowertoolsPython:3",
+          "arn:aws:lambda:ap-northeast-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:60",
           "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:14",
         ],
         "MemorySize": 256,
@@ -965,7 +965,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.12",
         "Timeout": 25,
         "TracingConfig": {
           "Mode": "Active",
@@ -1135,7 +1135,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           ],
         },
         "Layers": [
-          "arn:aws:lambda:ap-northeast-1:017000801446:layer:AWSLambdaPowertoolsPython:3",
+          "arn:aws:lambda:ap-northeast-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:60",
           "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:14",
         ],
         "MemorySize": 2048,
@@ -1145,7 +1145,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.12",
         "Timeout": 25,
         "TracingConfig": {
           "Mode": "Active",
@@ -1315,7 +1315,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           ],
         },
         "Layers": [
-          "arn:aws:lambda:ap-northeast-1:017000801446:layer:AWSLambdaPowertoolsPython:3",
+          "arn:aws:lambda:ap-northeast-1:017000801446:layer:AWSLambdaPowertoolsPythonV2:60",
           "arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:14",
         ],
         "MemorySize": 256,
@@ -1325,7 +1325,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
             "Arn",
           ],
         },
-        "Runtime": "python3.7",
+        "Runtime": "python3.12",
         "Timeout": 25,
         "TracingConfig": {
           "Mode": "Active",

--- a/usecases/blea-guest-serverless-api-sample/test/__snapshots__/blea-guest-apiapp-nodejs-sample.test.ts.snap
+++ b/usecases/blea-guest-serverless-api-sample/test/__snapshots__/blea-guest-apiapp-nodejs-sample.test.ts.snap
@@ -77,7 +77,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "2a9875eb37263cf2556e6f088d5f20034e2fd3b8c2176c6332c8a8fcfc3cfd2a.zip",
+          "S3Key": "5eb6ebc45f9cfa13a3ba774c97aea934486a71239782a08415cc5a7a01b0e39c.zip",
         },
         "Environment": {
           "Variables": {
@@ -257,7 +257,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "68a11c84212c3eff28df00c3bf5918304911369738721962565d7b7e22635f1d.zip",
+          "S3Key": "3e9bfabe006a930bbeb651bd235b5cea7bcb1534bc0982ab4a8a7ed54a63d5e5.zip",
         },
         "Environment": {
           "Variables": {
@@ -437,7 +437,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "8f98da062af0ac11372a014910ace092e8d07c085ee89aac238241a5b6b7c6f5.zip",
+          "S3Key": "f0f5bc4e4bc6c745dab0589c34635dc0fcca0d4af256a6b380758b9df224b1a0.zip",
         },
         "Environment": {
           "Variables": {


### PR DESCRIPTION
## Overview

Update the outdated version of the Lambda Runtime within the blea-guest-serverless-api-sample.
- NODEJS_14_X to NODEJS_LATEST(now NODEJS_18_X)
- PYTHON_3_7 to PYTHON_3_12
  - Update the Layer to use Powertools compatible with Python 3.12.

## Test

- Deploy the resources and send a request to the endpoint. Verify that a successful response is returned.

```
# Node.js

curl -X POST https://xxxxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/nodejs/item -d '{"title":"hoge","content":"body desu"}'
"Success to putItem to the DynamoDB"
curl https://xxxxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/nodejs/list                                               
[{"content":{"S":"body desu"},"title":{"S":"hoge"},"created_at":{"S":"Thu Jun 13 2024 06:51:33 GMT+0000 (Coordinated Universal Time)"}}]% 
curl https://xxxxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/nodejs/item/hoge
[{"content":{"S":"body desu"},"title":{"S":"hoge"},"created_at":{"S":"Thu Jun 13 2024 06:51:33 GMT+0000 (Coordinated Universal Time)"}}]% 

# Python

curl -X POST https://xxxxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/python/item -d '{"title":"hoge2","content":"body desu 2"}'
{"Success": "Success to putItem to the DynamoDB"}% 
curl https://xxxxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/python/item/hoge2
[{"content": "body desu 2", "title": "hoge2", "created_at": "2024-06-13 07:40:34.444497"}]
curl https://xxxxxxxxxxxx.execute-api.ap-northeast-1.amazonaws.com/prod/python/item/list
[{"content": "body desu 2", "title": "hoge2", "created_at": "2024-06-13 07:40:34.444497"}]

```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
