### PR TITLE
build: Ignore asset changes in snapshot tests

### DIFF
--- a/usecases/blea-gov-base-ct/jest.config.js
+++ b/usecases/blea-gov-base-ct/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  snapshotSerializers: ['<rootDir>/test/plugin/ignore-assets-snapshot-selializer.ts'],
 };

--- a/usecases/blea-gov-base-ct/test/__snapshots__/blea-gov-base-ct-via-service-catalog.test.ts.snap
+++ b/usecases/blea-gov-base-ct/test/__snapshots__/blea-gov-base-ct-via-service-catalog.test.ts.snap
@@ -62,7 +62,7 @@ exports[`Snapshot test for BLEGovABase Stack 1`] = `
             "DisableTemplateValidation": false,
             "Info": {
               "LoadTemplateFromURL": {
-                "Fn::Sub": "https://s3.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}/e3ed32ec5c9eeee3f6c2a9266d975e5a5c8741e45c898f191844134fc88e8251.json",
+                "Fn::Sub": "https://s3.\${AWS::Region}.\${AWS::URLSuffix}/cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}/HASH-REPLACED.json",
               },
             },
             "Name": "v1",

--- a/usecases/blea-gov-base-ct/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-gov-base-ct/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -1,0 +1,7 @@
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+module.exports = {
+  test: (val: any) => typeof val === 'string',
+  serialize: (val: any) => {
+    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+  },
+};

--- a/usecases/blea-gov-base-standalone/jest.config.js
+++ b/usecases/blea-gov-base-standalone/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  snapshotSerializers: ['<rootDir>/test/plugin/ignore-assets-snapshot-selializer.ts'],
 };

--- a/usecases/blea-gov-base-standalone/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-gov-base-standalone/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -1,0 +1,7 @@
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+module.exports = {
+  test: (val: any) => typeof val === 'string',
+  serialize: (val: any) => {
+    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+  },
+};

--- a/usecases/blea-guest-ec2-app-sample/jest.config.js
+++ b/usecases/blea-guest-ec2-app-sample/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  snapshotSerializers: ['<rootDir>/test/plugin/ignore-assets-snapshot-selializer.ts'],
 };

--- a/usecases/blea-guest-ec2-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-guest-ec2-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -1,0 +1,7 @@
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+module.exports = {
+  test: (val: any) => typeof val === 'string',
+  serialize: (val: any) => {
+    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+  },
+};

--- a/usecases/blea-guest-ecs-app-sample/jest.config.js
+++ b/usecases/blea-guest-ecs-app-sample/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  snapshotSerializers: ['<rootDir>/test/plugin/ignore-assets-snapshot-selializer.ts'],
 };

--- a/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
+++ b/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample.test.ts.snap
@@ -179,7 +179,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "246cb27aa0cb552c81fdca061092d0905aa4d2529e8b52b5598c069f18be51d7.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -1662,7 +1662,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "4e26bf2d0a26f2097fb2b261f22bb51e3f6b4b52635777b1e54edbd8e2d58c35.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Handler": "index.handler",
         "Role": {
@@ -3238,7 +3238,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "8acca95a9957d02a9f3ec124c9869c5d5b70a7fb3e332120850781ecc9363037.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -3318,7 +3318,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 2`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-us-east-1",
           },
-          "S3Key": "246cb27aa0cb552c81fdca061092d0905aa4d2529e8b52b5598c069f18be51d7.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -4039,7 +4039,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "1e64e462d93160eb5230b00e665705bfaf2299d9c302ab56dd093bccbe387c4f.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "ExecutionRoleArn": {
           "Fn::GetAtt": [
@@ -4171,7 +4171,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 3`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "8acca95a9957d02a9f3ec124c9869c5d5b70a7fb3e332120850781ecc9363037.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,

--- a/usecases/blea-guest-ecs-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-guest-ecs-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -1,0 +1,7 @@
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+module.exports = {
+  test: (val: any) => typeof val === 'string',
+  serialize: (val: any) => {
+    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+  },
+};

--- a/usecases/blea-guest-serverless-api-sample/jest.config.js
+++ b/usecases/blea-guest-serverless-api-sample/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  snapshotSerializers: ['<rootDir>/test/plugin/ignore-assets-snapshot-selializer.ts'],
 };

--- a/usecases/blea-guest-serverless-api-sample/test/__snapshots__/blea-guest-apiapp-nodejs-sample.test.ts.snap
+++ b/usecases/blea-guest-serverless-api-sample/test/__snapshots__/blea-guest-apiapp-nodejs-sample.test.ts.snap
@@ -77,7 +77,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "24d4f265d3247b1610b7f57ce43bb345dfd6b075ba64687ade414a8a42532238.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Environment": {
           "Variables": {
@@ -256,7 +256,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "747f7c73d211501164b73a22c6f8188aa6b8ea5a4926b9e33c7e9a23d24e21b8.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Environment": {
           "Variables": {
@@ -435,7 +435,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "34013c203865c2bd724a8ae1c4541041fad361700407ea72f9fd6aaa861a36cf.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Environment": {
           "Variables": {
@@ -935,7 +935,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "6c6248559cf324952895870a3b546cf7cbfbafe0cce9e4a60bc61e6ec8eef051.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Environment": {
           "Variables": {
@@ -1115,7 +1115,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "9935294482ff6ee39a0af20cfbf740c113a6d493e51300bfd6e98e85e6e9f360.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Environment": {
           "Variables": {
@@ -1295,7 +1295,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "dc0a332c2c8fb4d4e7977a51466ff04fda2926977fd3f496acfa00722ded9563.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Environment": {
           "Variables": {
@@ -2844,7 +2844,7 @@ exports[`Snapshot test for ServerlessApi Stack 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-ap-northeast-1",
           },
-          "S3Key": "4e26bf2d0a26f2097fb2b261f22bb51e3f6b4b52635777b1e54edbd8e2d58c35.zip",
+          "S3Key": "HASH-REPLACED.zip",
         },
         "Handler": "index.handler",
         "Role": {

--- a/usecases/blea-guest-serverless-api-sample/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-guest-serverless-api-sample/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -1,0 +1,7 @@
+/* eslint @typescript-eslint/no-explicit-any: 0 */
+module.exports = {
+  test: (val: any) => typeof val === 'string',
+  serialize: (val: any) => {
+    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+  },
+};


### PR DESCRIPTION
In this repository, Dependabot automatically updates dependent packages. However, when AWS SDK, X-Ray, and others are updated, asset hash of Lambda functions changes, making it impossible to merge automatically. To avoid this, using Jest's functionality to replace asset hash with a fixed string in snapshot tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
