### PR TITLE
build: Avoid ESLint OOM

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,8 @@
   "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.json",
+    "EXPERIMENTAL_useProjectService": true
   },
   "plugins": ["@typescript-eslint"],
   "rules": {}


### PR DESCRIPTION
When lint-staged runs `eslint --fix`, we get the error: 

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

To avoid this, set a parser option to ESLint.

https://github.com/typescript-eslint/typescript-eslint/issues/1192#issuecomment-2071711326

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
