### PR TITLE
fix: rm eslint & prettier from ignoreDependencies in knip config

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -9,7 +9,6 @@ export default {
       entry: ['bin/*.ts', 'lambda/**/*.{js,ts}'],
       project: '**/*.{js,ts}',
       ignore: ['parameter.ts'], // FIXME: ignore to avoid unused errors on `stagingParameter`. We should use all sample values.
-      ignoreDependencies: ['eslint', 'prettier'],
     },
   },
 } as const satisfies KnipConfig;


### PR DESCRIPTION
When we migrated `depcheck` to `knip` in #924 , we forgot to remove `prettier` and `eslint` from `ignoreDependencies` in `knip.config.ts`. Therefore I've removed them.

ref: https://github.com/aws-samples/baseline-environment-on-aws/pull/924#pullrequestreview-2490925750

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
