### PR TITLE
feat: add barrel to self-made constructs

### DIFF
--- a/usecases/blea-gov-base-ct/lib/construct/index.ts
+++ b/usecases/blea-gov-base-ct/lib/construct/index.ts
@@ -1,0 +1,4 @@
+export * from './detection';
+export * from './iam';
+export * from './logging';
+export * from './notification';

--- a/usecases/blea-gov-base-ct/lib/stack/blea-gov-base-ct-stack.ts
+++ b/usecases/blea-gov-base-ct/lib/stack/blea-gov-base-ct-stack.ts
@@ -1,9 +1,6 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Iam } from '../construct/iam';
-import { Logging } from '../construct/logging';
-import { Detection } from '../construct/detection';
-import { Notification } from '../construct/notification';
+import { Detection, Iam, Logging, Notification } from '../construct';
 
 export interface BLEAGovBaseCtStackProps extends StackProps {
   securityNotifyEmail: string;

--- a/usecases/blea-gov-base-ct/lib/stack/blea-gov-base-ct-via-service-catalog-stack.ts
+++ b/usecases/blea-gov-base-ct/lib/stack/blea-gov-base-ct-via-service-catalog-stack.ts
@@ -1,10 +1,8 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import { CloudFormationProduct, Portfolio, ProductStack, ProductStackHistory } from 'aws-cdk-lib/aws-servicecatalog';
-import { Iam } from '../construct/iam';
-import { Logging } from '../construct/logging';
-import { Detection } from '../construct/detection';
 import { Role } from 'aws-cdk-lib/aws-iam';
+import { Detection, Iam, Logging } from '../construct';
 
 export interface BLEAGovBaseCtScStackProps extends StackProps {
   securityNotifyEmail: string;

--- a/usecases/blea-gov-base-ct/lib/stage/blea-gov-base-ct-stage.ts
+++ b/usecases/blea-gov-base-ct/lib/stage/blea-gov-base-ct-stage.ts
@@ -1,8 +1,6 @@
 import { Stack, Stage } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Detection } from '../construct/detection';
-import { Iam } from '../construct/iam';
-import { Logging } from '../construct/logging';
+import { Detection, Iam, Logging } from '../construct';
 import { BLEAGovBaseCtStackProps } from '../stack/blea-gov-base-ct-stack';
 
 export class BLEAGovBaseCtStage extends Stage {

--- a/usecases/blea-gov-base-standalone/lib/construct/index.ts
+++ b/usecases/blea-gov-base-standalone/lib/construct/index.ts
@@ -1,0 +1,4 @@
+export * from './detection';
+export * from './iam';
+export * from './logging';
+export * from './notification';

--- a/usecases/blea-gov-base-standalone/lib/stack/blea-gov-base-standalone-stack.ts
+++ b/usecases/blea-gov-base-standalone/lib/stack/blea-gov-base-standalone-stack.ts
@@ -1,9 +1,6 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { Detection } from '../construct/detection';
-import { Iam } from '../construct/iam';
-import { Logging } from '../construct/logging';
-import { Notification } from '../construct/notification';
+import { Detection, Iam, Logging, Notification } from '../construct';
 
 export interface BLEAGovBaseStandaloneProps extends StackProps {
   securityNotifyEmail: string;

--- a/usecases/blea-guest-ec2-app-sample/lib/construct/index.ts
+++ b/usecases/blea-guest-ec2-app-sample/lib/construct/index.ts
@@ -1,0 +1,4 @@
+export * from './ec2app';
+export * from './investigation-instance';
+export * from './monitoring';
+export * from './networking';

--- a/usecases/blea-guest-ec2-app-sample/lib/stack/blea-guest-ec2-app-sample-stack.ts
+++ b/usecases/blea-guest-ec2-app-sample/lib/stack/blea-guest-ec2-app-sample-stack.ts
@@ -1,10 +1,7 @@
 import { Names, Stack, StackProps } from 'aws-cdk-lib';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Construct } from 'constructs';
-import { Ec2App } from '../construct/ec2app';
-import { Monitoring } from '../construct/monitoring';
-import { Networking } from '../construct/networking';
-import { InvestigationInstance } from '../construct/investigation-instance';
+import { Ec2App, Monitoring, Networking, InvestigationInstance } from '../construct';
 
 export interface BLEAEc2AppStackProps extends StackProps {
   monitoringNotifyEmail: string;

--- a/usecases/blea-guest-ecs-app-sample/lib/construct/index.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/construct/index.ts
@@ -1,0 +1,7 @@
+export * from './canary';
+export * from './dashboard';
+export * from './datastore';
+export * from './ecsapp';
+export * from './frontend';
+export * from './monitoring';
+export * from './networking';

--- a/usecases/blea-guest-ecs-app-sample/lib/stack/blea-guest-ecs-app-frontend-stack.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/stack/blea-guest-ecs-app-frontend-stack.ts
@@ -1,8 +1,8 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { ITopic } from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
-import { Frontend } from '../construct/frontend';
 import { ILoadBalancerV2 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Frontend } from '../construct';
 
 export interface BLEAEcsAppFrontendStackProps extends StackProps {
   alarmTopic: ITopic;

--- a/usecases/blea-guest-ecs-app-sample/lib/stack/blea-guest-ecs-app-monitoring-stack.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/stack/blea-guest-ecs-app-monitoring-stack.ts
@@ -2,8 +2,7 @@ import { Stack, StackProps } from 'aws-cdk-lib';
 import { IAlarm } from 'aws-cdk-lib/aws-cloudwatch';
 import { ITopic } from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
-import { Dashboard } from '../construct/dashboard';
-import { Canary } from '../construct/canary';
+import { Canary, Dashboard } from '../construct';
 
 export interface BLEAEcsAppMonitoringStackProps extends StackProps {
   alarmTopic: ITopic;

--- a/usecases/blea-guest-ecs-app-sample/lib/stack/blea-guest-ecs-app-sample-stack.ts
+++ b/usecases/blea-guest-ecs-app-sample/lib/stack/blea-guest-ecs-app-sample-stack.ts
@@ -3,11 +3,8 @@ import { IAlarm } from 'aws-cdk-lib/aws-cloudwatch';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { ITopic } from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
-import { Datastore } from '../construct/datastore';
-import { EcsApp } from '../construct/ecsapp';
-import { Monitoring } from '../construct/monitoring';
-import { Networking } from '../construct/networking';
 import { ILoadBalancerV2 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { Datastore, EcsApp, Monitoring, Networking } from '../construct';
 
 export interface BLEAEcsAppStackProps extends StackProps {
   monitoringNotifyEmail: string;

--- a/usecases/blea-guest-serverless-api-sample/lib/construct/index.ts
+++ b/usecases/blea-guest-serverless-api-sample/lib/construct/index.ts
@@ -1,0 +1,5 @@
+export * from './api';
+export * from './datastore';
+export * from './lambda-nodejs';
+export * from './lambda-python';
+export * from './monitoring';

--- a/usecases/blea-guest-serverless-api-sample/lib/stack/blea-guest-serverless-api-sample-stack.ts
+++ b/usecases/blea-guest-serverless-api-sample/lib/stack/blea-guest-serverless-api-sample-stack.ts
@@ -1,9 +1,7 @@
 import { Names, Stack, StackProps } from 'aws-cdk-lib';
 import { Key } from 'aws-cdk-lib/aws-kms';
 import { Construct } from 'constructs';
-import { Api } from '../construct/api';
-import { Datastore } from '../construct/datastore';
-import { Monitoring } from '../construct/monitoring';
+import { Api, Datastore, Monitoring } from '../construct';
 
 export interface BLEAServerlessApiStackProps extends StackProps {
   monitoringNotifyEmail: string;


### PR DESCRIPTION
##  Add Barrel File for `/lib/construct` Directory

This PR introduces a barrel file (`index.ts`) in the `/lib/construct` directory to streamline the import of custom constructs across the project. By using a centralized export file, the readability, maintainability, and consistency of import statements are improved.

### Benefits
1. **Simplified Imports**: Developers can now import constructs using a single path, reducing clutter in the import statements.
   ```ts
   // Before
   import { MyConstructA } from './lib/construct/MyConstructA';
   import { MyConstructB } from './lib/construct/MyConstructB';
   import { MyConstructC } from './lib/construct/MyConstructC';

   // After
   import { MyConstructA, MyConstructB, MyConstructC } from './lib/construct';
   ```

2. **Scalability**: Adding new constructs in the future will only require updating the barrel file, keeping the import structure consistent.

### Considerations

I considered the same for `/lib/stack`, but decided that the barrel file was no longer useful due to the increasing adoption of single stack.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
