### PR TITLE
feat: notification on GuardDuty findings via SecurityHub

### DIFF
--- a/usecases/blea-gov-base-ct/lib/construct/detection.ts
+++ b/usecases/blea-gov-base-ct/lib/construct/detection.ts
@@ -356,7 +356,7 @@ export class Detection extends Construct {
     });
 
     // GuardDutyFindings
-    //   Will alert for any Medium to High finding.
+    //   Will alert for any Medium to Critical finding.
     //   See: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html
     new cwe.Rule(this, 'GuardDutyEventRule', {
       description: 'CloudWatch Event Rule to send notification on GuardDuty findings.',
@@ -368,7 +368,7 @@ export class Detection extends Construct {
           severity: [
             4, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6,
             6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8,
-            8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9,
+            8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10, 10.0,
           ],
         },
       },

--- a/usecases/blea-gov-base-ct/lib/construct/detection.ts
+++ b/usecases/blea-gov-base-ct/lib/construct/detection.ts
@@ -355,21 +355,22 @@ export class Detection extends Construct {
       targets: [new cwet.SnsTopic(topic)],
     });
 
-    // GuardDutyFindings
+    // GuardDutyFindings via SecurityHub
     //   Will alert for any Medium to Critical finding.
     //   See: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html
-    new cwe.Rule(this, 'GuardDutyEventRule', {
-      description: 'CloudWatch Event Rule to send notification on GuardDuty findings.',
+    new cwe.Rule(this, 'GuardDutyEventRuleViaSecurityHub', {
+      description: 'CloudWatch Event Rule to send notification on GuardDuty findings via SecurityHub.',
       enabled: true,
       eventPattern: {
-        source: ['aws.guardduty'],
-        detailType: ['GuardDuty Finding'],
+        source: ['aws.securityhub'],
+        detailType: ['Security Hub Findings - Imported'],
         detail: {
-          severity: [
-            4, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6,
-            6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8,
-            8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10, 10.0,
-          ],
+          findings: {
+            ProductName: ['GuardDuty'],
+            Severity: {
+              Label: ['CRITICAL', 'HIGH', 'MEDIUM'],
+            },
+          },
         },
       },
       targets: [new cwet.SnsTopic(topic)],

--- a/usecases/blea-gov-base-standalone/lib/construct/detection.ts
+++ b/usecases/blea-gov-base-standalone/lib/construct/detection.ts
@@ -375,7 +375,7 @@ export class Detection extends Construct {
     });
 
     // GuardDutyFindings
-    //   Will alert for any Medium to High finding.
+    //   Will alert for any Medium to Critical finding.
     //   See: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html
     new cwe.Rule(this, 'GuardDutyEventRule', {
       description: 'CloudWatch Event Rule to send notification on GuardDuty findings.',
@@ -387,7 +387,7 @@ export class Detection extends Construct {
           severity: [
             4, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6,
             6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8,
-            8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9,
+            8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10, 10.0,
           ],
         },
       },

--- a/usecases/blea-gov-base-standalone/lib/construct/detection.ts
+++ b/usecases/blea-gov-base-standalone/lib/construct/detection.ts
@@ -374,21 +374,22 @@ export class Detection extends Construct {
       targets: [new cwet.SnsTopic(topic)],
     });
 
-    // GuardDutyFindings
+    // GuardDutyFindings via SecurityHub
     //   Will alert for any Medium to Critical finding.
     //   See: https://docs.aws.amazon.com/guardduty/latest/ug/guardduty_findings_cloudwatch.html
-    new cwe.Rule(this, 'GuardDutyEventRule', {
-      description: 'CloudWatch Event Rule to send notification on GuardDuty findings.',
+    new cwe.Rule(this, 'GuardDutyEventRuleViaSecurityHub', {
+      description: 'CloudWatch Event Rule to send notification on GuardDuty findings via SecurityHub.',
       enabled: true,
       eventPattern: {
-        source: ['aws.guardduty'],
-        detailType: ['GuardDuty Finding'],
+        source: ['aws.securityhub'],
+        detailType: ['Security Hub Findings - Imported'],
         detail: {
-          severity: [
-            4, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.6, 4.7, 4.8, 4.9, 5, 5.0, 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7, 5.8, 5.9, 6,
-            6.0, 6.1, 6.2, 6.3, 6.4, 6.5, 6.6, 6.7, 6.8, 6.9, 7, 7.0, 7.1, 7.2, 7.3, 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8,
-            8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 8.9, 9, 9.0, 9.1, 9.2, 9.3, 9.4, 9.5, 9.6, 9.7, 9.8, 9.9, 10, 10.0,
-          ],
+          findings: {
+            ProductName: ['GuardDuty'],
+            Severity: {
+              Label: ['CRITICAL', 'HIGH', 'MEDIUM'],
+            },
+          },
         },
       },
       targets: [new cwet.SnsTopic(topic)],


### PR DESCRIPTION
- CloudWatch Event Rule to send notification on GuardDuty findings: via GuardDuty -> via SecurityHub
- Alert severity: Medium to High -> Medium to Critical

If this PR is merged, #1140 should be closed.

issue #1139


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT No Attribution (MIT-0)].

[MIT No Attribution (MIT-0)]: https://github.com/aws/mit-0
