### PR TITLE
test: improve snapshot serializer to normalize environment-dependent asset hashes

### DIFF
--- a/usecases/blea-gov-base-ct/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-gov-base-ct/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -2,6 +2,11 @@
 module.exports = {
   test: (val: any) => typeof val === 'string',
   serialize: (val: any) => {
-    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+    return `"${val.replace(/[A-Fa-f0-9]{64}(\.zip|\.json|:[A-Za-z0-9_-]*)/g, (match: string, suffix: string) => {
+      // Normalize trailing short hash (6-8 hex chars) in asset identifiers
+      // to avoid environment-dependent snapshot differences (e.g., Node.js version)
+      const normalized = suffix.replace(/-[A-Fa-f0-9]{6,8}$/, '-SHORTHASH');
+      return 'HASH-REPLACED' + normalized;
+    })}"`;
   },
 };

--- a/usecases/blea-gov-base-standalone/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-gov-base-standalone/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -2,6 +2,11 @@
 module.exports = {
   test: (val: any) => typeof val === 'string',
   serialize: (val: any) => {
-    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+    return `"${val.replace(/[A-Fa-f0-9]{64}(\.zip|\.json|:[A-Za-z0-9_-]*)/g, (match: string, suffix: string) => {
+      // Normalize trailing short hash (6-8 hex chars) in asset identifiers
+      // to avoid environment-dependent snapshot differences (e.g., Node.js version)
+      const normalized = suffix.replace(/-[A-Fa-f0-9]{6,8}$/, '-SHORTHASH');
+      return 'HASH-REPLACED' + normalized;
+    })}"`;
   },
 };

--- a/usecases/blea-guest-ec2-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-guest-ec2-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -2,6 +2,11 @@
 module.exports = {
   test: (val: any) => typeof val === 'string',
   serialize: (val: any) => {
-    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+    return `"${val.replace(/[A-Fa-f0-9]{64}(\.zip|\.json|:[A-Za-z0-9_-]*)/g, (match: string, suffix: string) => {
+      // Normalize trailing short hash (6-8 hex chars) in asset identifiers
+      // to avoid environment-dependent snapshot differences (e.g., Node.js version)
+      const normalized = suffix.replace(/-[A-Fa-f0-9]{6,8}$/, '-SHORTHASH');
+      return 'HASH-REPLACED' + normalized;
+    })}"`;
   },
 };

--- a/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample-pipeline.test.ts.snap
+++ b/usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample-pipeline.test.ts.snap
@@ -993,7 +993,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
     },
     "build": {
       "commands": [
-        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsApp6C10F018.assets.json\\" --verbose publish \\"4e26bf2d0a26f2097fb2b261f22bb51e3f6b4b52635777b1e54edbd8e2d58c35:current_account-ap-northeast-1\\""
+        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsApp6C10F018.assets.json\\" --verbose publish \\"HASH-REPLACED:current_account-ap-northeast-1\\""
       ]
     }
   }
@@ -1042,8 +1042,8 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
     },
     "build": {
       "commands": [
-        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsApp6C10F018.assets.json\\" --verbose publish \\"246cb27aa0cb552c81fdca061092d0905aa4d2529e8b52b5598c069f18be51d7:current_account-ap-northeast-1\\"",
-        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsFrontendDCC2248E.assets.json\\" --verbose publish \\"246cb27aa0cb552c81fdca061092d0905aa4d2529e8b52b5598c069f18be51d7:current_account-us-east-1\\""
+        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsApp6C10F018.assets.json\\" --verbose publish \\"HASH-REPLACED:current_account-ap-northeast-1\\"",
+        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsFrontendDCC2248E.assets.json\\" --verbose publish \\"HASH-REPLACED:current_account-us-east-1\\""
       ]
     }
   }
@@ -1092,8 +1092,8 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
     },
     "build": {
       "commands": [
-        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsFrontendDCC2248E.assets.json\\" --verbose publish \\"8acca95a9957d02a9f3ec124c9869c5d5b70a7fb3e332120850781ecc9363037:current_account-us-east-1\\"",
-        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsAppMonitoringADD43E1F.assets.json\\" --verbose publish \\"8acca95a9957d02a9f3ec124c9869c5d5b70a7fb3e332120850781ecc9363037:current_account-ap-northeast-1\\""
+        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsFrontendDCC2248E.assets.json\\" --verbose publish \\"HASH-REPLACED:current_account-us-east-1\\"",
+        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsAppMonitoringADD43E1F.assets.json\\" --verbose publish \\"HASH-REPLACED:current_account-ap-northeast-1\\""
       ]
     }
   }
@@ -1142,7 +1142,7 @@ exports[`Snapshot test for BLEA ECS App Stacks 1`] = `
     },
     "build": {
       "commands": [
-        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsAppMonitoringADD43E1F.assets.json\\" --verbose publish \\"1e64e462d93160eb5230b00e665705bfaf2299d9c302ab56dd093bccbe387c4f:current_account-ap-northeast-1\\""
+        "cdk-assets --path \\"assembly-Dev-BLEAEcsAppPipeline-Dev/DevBLEAEcsAppPipelineDevBLEAEcsAppMonitoringADD43E1F.assets.json\\" --verbose publish \\"HASH-REPLACED:current_account-ap-northeast-1\\""
       ]
     }
   }

--- a/usecases/blea-guest-ecs-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-guest-ecs-app-sample/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -2,6 +2,11 @@
 module.exports = {
   test: (val: any) => typeof val === 'string',
   serialize: (val: any) => {
-    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+    return `"${val.replace(/[A-Fa-f0-9]{64}(\.zip|\.json|:[A-Za-z0-9_-]*)/g, (match: string, suffix: string) => {
+      // Normalize trailing short hash (6-8 hex chars) in asset identifiers
+      // to avoid environment-dependent snapshot differences (e.g., Node.js version)
+      const normalized = suffix.replace(/-[A-Fa-f0-9]{6,8}$/, '-SHORTHASH');
+      return 'HASH-REPLACED' + normalized;
+    })}"`;
   },
 };

--- a/usecases/blea-guest-serverless-api-sample/test/plugin/ignore-assets-snapshot-selializer.ts
+++ b/usecases/blea-guest-serverless-api-sample/test/plugin/ignore-assets-snapshot-selializer.ts
@@ -2,6 +2,11 @@
 module.exports = {
   test: (val: any) => typeof val === 'string',
   serialize: (val: any) => {
-    return `"${val.replace(/[A-Fa-f0-9]{64}.(zip|json)/, 'HASH-REPLACED.$1')}"`;
+    return `"${val.replace(/[A-Fa-f0-9]{64}(\.zip|\.json|:[A-Za-z0-9_-]*)/g, (match: string, suffix: string) => {
+      // Normalize trailing short hash (6-8 hex chars) in asset identifiers
+      // to avoid environment-dependent snapshot differences (e.g., Node.js version)
+      const normalized = suffix.replace(/-[A-Fa-f0-9]{6,8}$/, '-SHORTHASH');
+      return 'HASH-REPLACED' + normalized;
+    })}"`;
   },
 };


### PR DESCRIPTION
## Summary

Improves the custom Jest snapshot serializer (`ignore-assets-snapshot-selializer.ts`) across all 5 usecases to eliminate environment-dependent snapshot mismatches.

## Problem

CDK pipeline snapshot tests produce different asset identifier suffixes depending on the Node.js version (e.g., Node 22 on CI vs Node 25 locally). This causes CI failures even when there are no real infrastructure changes.

Example diff that should not fail:
```
- HASH-REPLACED:current_account-ap-northeast-1-9897c67e  (CI / Node 22)
+ HASH-REPLACED:current_account-ap-northeast-1-b9434d22  (local / Node 25)
```

## Changes

1. **Add `g` (global) flag** — replace all hash occurrences in a string, not just the first
2. **Add colon-prefixed pattern** — match `HASH:account-region-shorthash` identifiers used in CDK pipeline asset publishing commands
3. **Normalize trailing short hashes** — replace 6-8 char hex suffixes with `SHORTHASH` to absorb environment differences
4. **Update ECS pipeline snapshot** — reflects the newly normalized format (raw 64-char hashes that were previously not caught are now replaced)

## Files Changed

- `usecases/*/test/plugin/ignore-assets-snapshot-selializer.ts` (all 5 usecases)
- `usecases/blea-guest-ecs-app-sample/test/__snapshots__/blea-guest-ecs-app-sample-pipeline.test.ts.snap`

## Context

This is a prerequisite for merging dependabot's aws-cdk-lib version bump (#1331), which introduces additional asset hash changes that would fail without this fix.